### PR TITLE
Enforce coverage thresholds in CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,4 +28,4 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npm run build --if-present
-    - run: npm test
+    - run: npm run test:coverage

--- a/package.json
+++ b/package.json
@@ -23,5 +23,20 @@
     "@vitejs/plugin-react": "^3.1.0",
     "typescript": "^4.9.5",
     "vite": "^4.1.4"
+  },
+  "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx}",
+      "!src/main.tsx",
+      "!src/vite-env.d.ts"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "statements": 90,
+        "branches": 90,
+        "functions": 90,
+        "lines": 90
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- CI (`node.js.yml`) ran plain `npm test`, so the existing `test:coverage` script was never invoked and coverage regressions were invisible.
- CI now runs `npm run test:coverage` instead.
- Added a `jest.coverageThreshold` (90% global on statements/branches/functions/lines) in `package.json`, scoped via `collectCoverageFrom` to `src/**/*.{ts,tsx}` excluding `src/main.tsx` (the ReactDOM bootstrap entry point, which isn't meaningfully unit-testable) and `src/vite-env.d.ts`.

## Test plan
- [x] `npm run test:coverage` — 100% statements/branches/functions/lines on `App.tsx`, well above the 90% threshold
- [x] Verified the threshold actually fails the build when unmet (temporarily set an impossible threshold locally, confirmed exit code 1, then reverted)
- [x] `npx tsc --noEmit` — clean
