### PR TITLE
Add Biome, wrap App in an ErrorBoundary, drop debug logging

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,6 +29,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'pnpm'
     - run: pnpm install --frozen-lockfile
+    - run: pnpm run lint
     - run: pnpm run build
     - run: pnpm run test:coverage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ number, most recent first.
 - End-to-end tests (Playwright) and automated accessibility scans (axe-core)
   covering the game flow, theme toggle, and initial/dark-mode/result states,
   wired into CI as a new `e2e` job alongside the existing unit test job.
+- Biome for linting and formatting, enforced in CI via a new `lint` step.
+- An `ErrorBoundary` around `<App />` so a rendering error shows a fallback
+  message instead of a blank page.
 
 ### Changed
 
@@ -23,6 +26,7 @@ number, most recent first.
   result message an announced live region (`role="status"`) and the theme
   toggle button reflect its pressed state (`aria-pressed`) — all surfaced by
   the new automated accessibility scans.
+- Removed leftover debug `console.log` calls in `useGuessColorsGame`.
 
 ## 2026-07-16
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ pnpm run e2e             # run end-to-end + accessibility tests (Playwright + ax
 pnpm run e2e:ui          # run e2e tests with Playwright's interactive UI
 pnpm run lint            # check linting and formatting (Biome)
 pnpm run lint:fix        # fix linting and formatting issues in place
+pnpm run format          # fix formatting only (no lint rules)
+pnpm run format:check    # check formatting only, without fixing
 ```
 
 ## 📂Project Structure

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This is a simple color guessing game built with React.js and Vite.js. The game i
 - Vite
 - Vitest + React Testing Library
 - Playwright + axe-core (end-to-end and accessibility testing)
+- Biome (linting and formatting)
 - pnpm
 
 ## 🖥️Development
@@ -50,6 +51,8 @@ pnpm test                # run the test suite
 pnpm run test:coverage   # run the test suite with a coverage report
 pnpm run e2e             # run end-to-end + accessibility tests (Playwright + axe)
 pnpm run e2e:ui          # run e2e tests with Playwright's interactive UI
+pnpm run lint            # check linting and formatting (Biome)
+pnpm run lint:fix        # fix linting and formatting issues in place
 ```
 
 ## 📂Project Structure

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "includes": ["**", "!!**/dist"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "preset": "recommended"
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1,6 +1,6 @@
-import { test, expect } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
-import { gotoHome, findAnswerButtons } from "./utils";
+import { expect, test } from "@playwright/test";
+import { findAnswerButtons, gotoHome } from "./utils";
 
 test("has no detectable accessibility violations on initial load", async ({
   page,

--- a/e2e/game-flow.spec.ts
+++ b/e2e/game-flow.spec.ts
@@ -1,11 +1,13 @@
-import { test, expect } from "@playwright/test";
-import { gotoHome, findAnswerButtons } from "./utils";
+import { expect, test } from "@playwright/test";
+import { findAnswerButtons, gotoHome } from "./utils";
 
 test("renders a color swatch and three answer buttons", async ({ page }) => {
   await gotoHome(page);
 
   await expect(page.getByTestId("guess-me")).toBeVisible();
-  await expect(page.getByRole("button", { name: /^#[0-9A-F]{6}$/ })).toHaveCount(3);
+  await expect(
+    page.getByRole("button", { name: /^#[0-9A-F]{6}$/ }),
+  ).toHaveCount(3);
 });
 
 test("clicking the correct answer shows the result and starts a new round", async ({
@@ -15,7 +17,7 @@ test("clicking the correct answer shows the result and starts a new round", asyn
 
   const swatch = page.getByTestId("guess-me");
   const initialBackground = await swatch.evaluate(
-    (el) => getComputedStyle(el).backgroundColor
+    (el) => getComputedStyle(el).backgroundColor,
   );
   const { correct } = await findAnswerButtons(page);
 

--- a/e2e/theme-toggle.spec.ts
+++ b/e2e/theme-toggle.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { gotoHome } from "./utils";
 
 test("toggles dark mode on and off via the theme button", async ({ page }) => {

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -20,7 +20,7 @@ async function getSwatchRgb(page: Page): Promise<[number, number, number]> {
   const rgbString = await page
     .getByTestId("guess-me")
     .evaluate((el) => getComputedStyle(el).backgroundColor);
-  const [r, g, b] = rgbString.match(/\d+/g)!.map(Number);
+  const [r, g, b] = (rgbString.match(/\d+/g) ?? []).map(Number);
   return [r, g, b];
 }
 
@@ -32,7 +32,7 @@ async function getSwatchRgb(page: Page): Promise<[number, number, number]> {
 // property key suffixes) on every fresh page load, consuming values ahead of
 // the app's own hook in a way a plain queued mock doesn't account for.
 export async function findAnswerButtons(
-  page: Page
+  page: Page,
 ): Promise<{ correct: Locator; wrong: Locator }> {
   const buttons = page.getByRole("button", { name: /^#[0-9A-F]{6}$/ });
   const swatchRgb = await getSwatchRgb(page);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
     "lint": "biome check .",
-    "lint:fix": "biome check --write ."
+    "lint:fix": "biome check --write .",
+    "format": "biome format --write .",
+    "format:check": "biome format ."
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "e2e": "playwright test",
-    "e2e:ui": "playwright test --ui"
+    "e2e:ui": "playwright test --ui",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write ."
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -19,6 +21,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",
+    "@biomejs/biome": "2.5.4",
     "@playwright/test": "1.56.1",
     "@testing-library/jest-dom": "^6.1.4",
     "@testing-library/react": "^14.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,5 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     timeout: 60_000,
   },
-  projects: [
-    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
-  ],
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@axe-core/playwright':
         specifier: ^4.12.1
         version: 4.12.1(playwright-core@1.56.1)
+      '@biomejs/biome':
+        specifier: 2.5.4
+        version: 2.5.4
       '@playwright/test':
         specifier: 1.56.1
         version: 1.56.1
@@ -167,6 +170,63 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@biomejs/biome@2.5.4':
+    resolution: {integrity: sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.5.4':
+    resolution: {integrity: sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.5.4':
+    resolution: {integrity: sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.5.4':
+    resolution: {integrity: sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.5.4':
+    resolution: {integrity: sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.5.4':
+    resolution: {integrity: sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.5.4':
+    resolution: {integrity: sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.5.4':
+    resolution: {integrity: sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.5.4':
+    resolution: {integrity: sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -1516,6 +1576,41 @@ snapshots:
       '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@biomejs/biome@2.5.4':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.5.4
+      '@biomejs/cli-darwin-x64': 2.5.4
+      '@biomejs/cli-linux-arm64': 2.5.4
+      '@biomejs/cli-linux-arm64-musl': 2.5.4
+      '@biomejs/cli-linux-x64': 2.5.4
+      '@biomejs/cli-linux-x64-musl': 2.5.4
+      '@biomejs/cli-win32-arm64': 2.5.4
+      '@biomejs/cli-win32-x64': 2.5.4
+
+  '@biomejs/cli-darwin-arm64@2.5.4':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.5.4':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.5.4':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.5.4':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.5.4':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.5.4':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.5.4':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.5.4':
+    optional: true
 
   '@bramus/specificity@2.4.2':
     dependencies:

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,19 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+  "name": "",
+  "short_name": "",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "display": "standalone"
+}

--- a/src/App.css
+++ b/src/App.css
@@ -1,17 +1,17 @@
-*{
+* {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
 }
 
-:root{
-  --background: #FFF;
-  --font: #000
+:root {
+  --background: #fff;
+  --font: #000;
 }
 
-.darkmode{
+.darkmode {
   --background: #1b1c25;
-  --font: #ffffff
+  --font: #ffffff;
 }
 
 .App {
@@ -56,7 +56,7 @@ button + button {
   text-align: center;
 }
 
-.theme-button{
+.theme-button {
   position: absolute;
   top: 30px;
   right: 30px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,12 @@
 import "./App.css";
-import { ColorSwatch } from "./components/ColorSwatch";
 import { AnswerOptions } from "./components/AnswerOptions";
+import { ColorSwatch } from "./components/ColorSwatch";
 import { ResultMessage } from "./components/ResultMessage";
 import { ThemeToggle } from "./components/ThemeToggle";
 import { useGuessColorsGame } from "./hooks/useGuessColorsGame";
 
 function App() {
-  const { color, answers, result, handleAnswerClicked } =
-    useGuessColorsGame();
+  const { color, answers, result, handleAnswerClicked } = useGuessColorsGame();
 
   return (
     <div className="App">

--- a/src/__tests__/ErrorBoundary.test.jsx
+++ b/src/__tests__/ErrorBoundary.test.jsx
@@ -1,0 +1,32 @@
+import { render } from "@testing-library/react";
+import { ErrorBoundary } from "../components/ErrorBoundary";
+
+function Bomb() {
+  throw new Error("boom");
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("renders children when there is no error", () => {
+  const { getByText } = render(
+    <ErrorBoundary>
+      <div>safe content</div>
+    </ErrorBoundary>,
+  );
+
+  expect(getByText("safe content")).toBeInTheDocument();
+});
+
+test("renders a fallback message when a child throws", () => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+
+  const { getByRole } = render(
+    <ErrorBoundary>
+      <Bomb />
+    </ErrorBoundary>,
+  );
+
+  expect(getByRole("alert")).toBeInTheDocument();
+});

--- a/src/__tests__/app.test.jsx
+++ b/src/__tests__/app.test.jsx
@@ -1,5 +1,5 @@
-import { render, fireEvent } from "@testing-library/react";
-import '@testing-library/jest-dom'
+import { fireEvent, render } from "@testing-library/react";
+import "@testing-library/jest-dom";
 import App from "../App";
 
 afterEach(() => {
@@ -16,7 +16,9 @@ function mockRandomSequence(...values) {
   const cyclingDefaults = [0.05, 0.2, 0.35, 0.5, 0.65, 0.8, 0.95];
   let cycleIndex = 0;
   const spy = vi.spyOn(Math, "random");
-  values.forEach((value) => spy.mockReturnValueOnce(value));
+  values.forEach((value) => {
+    spy.mockReturnValueOnce(value);
+  });
   spy.mockImplementation(() => {
     const value = cyclingDefaults[cycleIndex % cyclingDefaults.length];
     cycleIndex += 1;
@@ -39,7 +41,7 @@ test("checks for correct answer", () => {
   mockRandomSequence(
     0.1, // actual color -> #199999
     0.5, // distractor -> #7fffff
-    0.9 // distractor -> #e66665
+    0.9, // distractor -> #e66665
   );
 
   const { getByText, queryByText } = render(<App />);
@@ -53,7 +55,7 @@ test("checks for wrong answer", () => {
   mockRandomSequence(
     0.1, // actual color -> #199999
     0.5, // distractor -> #7fffff
-    0.9 // distractor -> #e66665
+    0.9, // distractor -> #e66665
   );
 
   const { getByText, queryByText } = render(<App />);
@@ -81,7 +83,7 @@ test("does not render duplicate answer colors when random draws collide", () => 
     0.1, // candidate collides with actual, rejected
     0.5, // distractor -> #7fffff
     0.5, // candidate collides with the distractor above, rejected
-    0.9 // distractor -> #e66665
+    0.9, // distractor -> #e66665
   );
 
   const { getAllByText } = render(<App />);
@@ -97,7 +99,7 @@ test("starts a new round immediately after a correct answer", () => {
   mockRandomSequence(
     0.1, // round 1 actual -> #199999
     0.5, // round 1 distractor -> #7fffff
-    0.9 // round 1 distractor -> #e66665
+    0.9, // round 1 distractor -> #e66665
   );
 
   const { getByText, queryByText, getByTestId } = render(<App />);
@@ -106,16 +108,14 @@ test("starts a new round immediately after a correct answer", () => {
   fireEvent.click(getByText("#199999"));
 
   expect(queryByText("Correct!")).toBeInTheDocument();
-  expect(getByTestId("guess-me").style.background).not.toBe(
-    initialBackground
-  );
+  expect(getByTestId("guess-me").style.background).not.toBe(initialBackground);
 });
 
 test("keeps the same round after a wrong answer, and can recover on the next guess", () => {
   mockRandomSequence(
     0.1, // actual -> #199999
     0.5, // distractor -> #7fffff
-    0.9 // distractor -> #e66665
+    0.9, // distractor -> #e66665
   );
 
   const { getByText, queryByText, getByTestId } = render(<App />);
@@ -125,7 +125,7 @@ test("keeps the same round after a wrong answer, and can recover on the next gue
 
   expect(queryByText("Wrong Answer")).toBeInTheDocument();
   expect(getByTestId("guess-me").style.background).toBe(
-    backgroundBeforeWrongGuess
+    backgroundBeforeWrongGuess,
   );
   expect(getByText("#199999")).toBeInTheDocument();
 

--- a/src/components/AnswerOptions.tsx
+++ b/src/components/AnswerOptions.tsx
@@ -7,7 +7,7 @@ export function AnswerOptions({ answers, onSelect }: AnswerOptionsProps) {
   return (
     <>
       {answers.map((answer) => (
-        <button onClick={() => onSelect(answer)} key={answer}>
+        <button type="button" onClick={() => onSelect(answer)} key={answer}>
           {answer.toUpperCase()}
         </button>
       ))}

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,36 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+type ErrorBoundaryProps = {
+  children: ReactNode;
+};
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+};
+
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("Uncaught error in GuessColors:", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="App" role="alert">
+          <p>Something went wrong. Please refresh the page to try again.</p>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/components/ResultMessage.tsx
+++ b/src/components/ResultMessage.tsx
@@ -9,14 +9,14 @@ export function ResultMessage({ result }: ResultMessageProps) {
     result === Result.Correct
       ? "correct"
       : result === Result.Wrong
-      ? "wrong"
-      : undefined;
+        ? "wrong"
+        : undefined;
   const message =
     result === Result.Correct
       ? "Correct!"
       : result === Result.Wrong
-      ? "Wrong Answer"
-      : "";
+        ? "Wrong Answer"
+        : "";
 
   return (
     <div role="status" className={className}>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 export function ThemeToggle() {
   const [isDarkMode, setIsDarkMode] = useState(() =>
-    document.body.classList.contains("darkmode")
+    document.body.classList.contains("darkmode"),
   );
 
   function changeTheme() {
@@ -11,6 +11,7 @@ export function ThemeToggle() {
 
   return (
     <button
+      type="button"
       className="theme-button"
       aria-pressed={isDarkMode}
       onClick={changeTheme}

--- a/src/hooks/useGuessColorsGame.ts
+++ b/src/hooks/useGuessColorsGame.ts
@@ -1,14 +1,14 @@
-import { useEffect, useState } from "react";
-import { generateRandomColor } from "../utils/color";
-import { shuffleArray } from "../utils/array";
+import { useCallback, useEffect, useState } from "react";
 import { Result } from "../types";
+import { shuffleArray } from "../utils/array";
+import { generateRandomColor } from "../utils/color";
 
 export function useGuessColorsGame() {
   const [color, setColor] = useState("");
   const [answers, setAnswers] = useState<string[]>([]);
   const [result, setResult] = useState<Result | undefined>(undefined);
 
-  const generateRandomColors = () => {
+  const generateRandomColors = useCallback(() => {
     const actualColor = generateRandomColor();
     const distractorColors = new Set<string>();
 
@@ -21,19 +21,17 @@ export function useGuessColorsGame() {
 
     setColor(actualColor);
     setAnswers(shuffleArray([actualColor, ...distractorColors]));
-  };
+  }, []);
 
   useEffect(() => {
     generateRandomColors();
-  }, []);
+  }, [generateRandomColors]);
 
   function handleAnswerClicked(answer: string): void {
     if (answer === color) {
-      console.log("Correct answer");
       setResult(Result.Correct);
       generateRandomColors();
     } else {
-      console.log("Wrong answer");
       setResult(Result.Wrong);
     }
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App'
-import './index.css'
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import { ErrorBoundary } from "./components/ErrorBoundary";
+import "./index.css";
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>,
-)
+);

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,5 +1,8 @@
 export const generateRandomColor = () => {
   return (
-    "#" + Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, "0")
+    "#" +
+    Math.floor(Math.random() * 0xffffff)
+      .toString(16)
+      .padStart(6, "0")
   );
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 /// <reference types="vitest/config" />
-import { defineConfig } from "vite";
+
 import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
- Add Biome for linting and formatting, enforced via a new CI lint
  step, and reformat the existing codebase to match (quotes, import
  order, trailing commas, button type attributes, exhaustive hook
  deps via useCallback).
- Wrap <App /> in an ErrorBoundary so a rendering error shows a
  fallback message instead of a blank page.
- Remove the two leftover console.log calls in
  useGuessColorsGame's handleAnswerClicked.