### PR TITLE
Add score/streak tracking, persistence, keyboard play, and animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ number, most recent first.
 - Biome for linting and formatting, enforced in CI via a new `lint` step.
 - An `ErrorBoundary` around `<App />` so a rendering error shows a fallback
   message instead of a blank page.
+- Score and streak tracking (`ScoreBoard`), with the all-time high score and
+  best streak persisted in `localStorage` (`src/utils/stats.ts`) so they
+  survive page reloads — the running score/streak reset each session.
+- Keyboard play: press 1, 2, or 3 to pick the corresponding answer button.
+- A smooth color transition on the swatch when a new round starts, and a
+  shake effect on a wrong answer, both disabled under
+  `prefers-reduced-motion`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ This is a simple color guessing game built with React.js and Vite.js. The game i
 - Click on the button that corresponds to the color of the box.
 - If you select the correct color, you will see a "Correct!" message.
 - If you select the wrong color, you will see a "Wrong Answer" message.
+- You can also press 1, 2, or 3 on your keyboard to pick the corresponding
+  answer button.
+- Your score and streak are tracked as you play, and your best score and
+  best streak are saved so they're there next time you visit.
 - Keep playing to test your color recognition skills!
 
 ## 💻Technologies Used
@@ -59,9 +63,10 @@ pnpm run format:check    # check formatting only, without fixing
 
 ## 📂Project Structure
 
-- `src/hooks/useGuessColorsGame.ts` — game state and logic (color generation, answer checking)
-- `src/components/` — presentational components (`ColorSwatch`, `AnswerOptions`, `ResultMessage`, `ThemeToggle`)
+- `src/hooks/useGuessColorsGame.ts` — game state and logic (color generation, answer checking, score/streak, keyboard play)
+- `src/components/` — presentational components (`ColorSwatch`, `AnswerOptions`, `ResultMessage`, `ThemeToggle`, `ScoreBoard`)
 - `src/utils/color.ts` — random color generation
+- `src/utils/stats.ts` — `localStorage` persistence for the all-time high score and best streak
 - `src/types.ts` — shared types
 - `src/App.tsx` — composes the hook and components together
 - `e2e/` — Playwright end-to-end and accessibility (axe-core) tests

--- a/e2e/animations.spec.ts
+++ b/e2e/animations.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+import { findAnswerButtons, gotoHome } from "./utils";
+
+test("applies a shake animation to the swatch on a wrong answer", async ({
+  page,
+}) => {
+  await gotoHome(page);
+
+  const { wrong } = await findAnswerButtons(page);
+  await wrong.click();
+
+  const swatch = page.getByTestId("guess-me");
+  await expect(swatch).toHaveClass(/shake/);
+  await expect(swatch).toHaveCSS("animation-name", "shake");
+});
+
+test("disables the shake animation under prefers-reduced-motion", async ({
+  page,
+}) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await gotoHome(page);
+
+  const { wrong } = await findAnswerButtons(page);
+  await wrong.click();
+
+  const swatch = page.getByTestId("guess-me");
+  await expect(swatch).toHaveCSS("animation-name", "none");
+});
+
+test("persists best score and streak across a reload, resetting the session totals", async ({
+  page,
+}) => {
+  await gotoHome(page);
+
+  const { correct } = await findAnswerButtons(page);
+  await correct.click();
+
+  await expect(page.getByText("Best Score: 1", { exact: true })).toBeVisible();
+  await expect(page.getByText("Best Streak: 1", { exact: true })).toBeVisible();
+
+  await page.reload();
+
+  await expect(page.getByText("Score: 0", { exact: true })).toBeVisible();
+  await expect(page.getByText("Streak: 0", { exact: true })).toBeVisible();
+  await expect(page.getByText("Best Score: 1", { exact: true })).toBeVisible();
+  await expect(page.getByText("Best Streak: 1", { exact: true })).toBeVisible();
+});

--- a/e2e/game-flow.spec.ts
+++ b/e2e/game-flow.spec.ts
@@ -43,3 +43,28 @@ test("clicking a wrong answer keeps the round going and can recover", async ({
 
   await expect(page.getByText("Correct!")).toBeVisible();
 });
+
+test("tracks score and streak across correct and wrong answers", async ({
+  page,
+}) => {
+  await gotoHome(page);
+
+  await expect(page.getByText("Score: 0", { exact: true })).toBeVisible();
+  await expect(page.getByText("Streak: 0", { exact: true })).toBeVisible();
+
+  const round1 = await findAnswerButtons(page);
+  await round1.correct.click();
+
+  await expect(page.getByText("Score: 1", { exact: true })).toBeVisible();
+  await expect(page.getByText("Streak: 1", { exact: true })).toBeVisible();
+
+  // The swatch's background-color transitions over 0.3s; let it settle
+  // before re-deriving the correct/wrong buttons from its rendered color.
+  await page.waitForTimeout(350);
+
+  const round2 = await findAnswerButtons(page);
+  await round2.wrong.click();
+
+  await expect(page.getByText("Score: 1", { exact: true })).toBeVisible();
+  await expect(page.getByText("Streak: 0", { exact: true })).toBeVisible();
+});

--- a/e2e/keyboard.spec.ts
+++ b/e2e/keyboard.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+import { findAnswerButtons, gotoHome } from "./utils";
+
+test("selects the correct answer with its number key", async ({ page }) => {
+  await gotoHome(page);
+
+  const { correctIndex } = await findAnswerButtons(page);
+
+  await page.keyboard.press(String(correctIndex + 1));
+
+  await expect(page.getByText("Correct!")).toBeVisible();
+});
+
+test("selects a wrong answer with its number key", async ({ page }) => {
+  await gotoHome(page);
+
+  const { wrongIndex } = await findAnswerButtons(page);
+
+  await page.keyboard.press(String(wrongIndex + 1));
+
+  await expect(page.getByText("Wrong Answer")).toBeVisible();
+});
+
+test("ignores number keys held with a modifier", async ({ page }) => {
+  await gotoHome(page);
+
+  const { correctIndex } = await findAnswerButtons(page);
+
+  await page.keyboard.down("Control");
+  await page.keyboard.press(String(correctIndex + 1));
+  await page.keyboard.up("Control");
+
+  await expect(page.getByText("Correct!")).not.toBeVisible();
+  await expect(page.getByText("Wrong Answer")).not.toBeVisible();
+});

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -31,15 +31,20 @@ async function getSwatchRgb(page: Page): Promise<[number, number, number]> {
 // module-level Math.random() calls (used internally for React's fiber
 // property key suffixes) on every fresh page load, consuming values ahead of
 // the app's own hook in a way a plain queued mock doesn't account for.
-export async function findAnswerButtons(
-  page: Page,
-): Promise<{ correct: Locator; wrong: Locator }> {
+export async function findAnswerButtons(page: Page): Promise<{
+  correct: Locator;
+  wrong: Locator;
+  correctIndex: number;
+  wrongIndex: number;
+}> {
   const buttons = page.getByRole("button", { name: /^#[0-9A-F]{6}$/ });
   const swatchRgb = await getSwatchRgb(page);
 
   const count = await buttons.count();
   let correct: Locator | undefined;
   let wrong: Locator | undefined;
+  let correctIndex: number | undefined;
+  let wrongIndex: number | undefined;
 
   for (let i = 0; i < count; i++) {
     const button = buttons.nth(i);
@@ -48,14 +53,21 @@ export async function findAnswerButtons(
     const isMatch = rgb.every((value, index) => value === swatchRgb[index]);
     if (isMatch) {
       correct = button;
+      correctIndex = i;
     } else if (!wrong) {
       wrong = button;
+      wrongIndex = i;
     }
   }
 
-  if (!correct || !wrong) {
+  if (
+    !correct ||
+    !wrong ||
+    correctIndex === undefined ||
+    wrongIndex === undefined
+  ) {
     throw new Error("Could not determine correct/wrong answer buttons");
   }
 
-  return { correct, wrong };
+  return { correct, wrong, correctIndex, wrongIndex };
 }

--- a/src/App.css
+++ b/src/App.css
@@ -28,6 +28,48 @@
   height: 200px;
   margin-bottom: 20px;
   border-radius: 4px;
+  transition: background-color 0.3s ease;
+}
+
+@keyframes shake {
+  10%,
+  90% {
+    transform: translateX(-1px);
+  }
+  20%,
+  80% {
+    transform: translateX(2px);
+  }
+  30%,
+  50%,
+  70% {
+    transform: translateX(-4px);
+  }
+  40%,
+  60% {
+    transform: translateX(4px);
+  }
+}
+
+.guess-me.shake {
+  animation: shake 0.4s ease;
+}
+
+.score-board {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 12px;
+  font-size: 14px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .guess-me {
+    transition: none;
+  }
+
+  .guess-me.shake {
+    animation: none;
+  }
 }
 
 button {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,18 +2,40 @@ import "./App.css";
 import { AnswerOptions } from "./components/AnswerOptions";
 import { ColorSwatch } from "./components/ColorSwatch";
 import { ResultMessage } from "./components/ResultMessage";
+import { ScoreBoard } from "./components/ScoreBoard";
 import { ThemeToggle } from "./components/ThemeToggle";
 import { useGuessColorsGame } from "./hooks/useGuessColorsGame";
+import { Result } from "./types";
 
 function App() {
-  const { color, answers, result, handleAnswerClicked } = useGuessColorsGame();
+  const {
+    color,
+    answers,
+    result,
+    score,
+    streak,
+    highScore,
+    bestStreak,
+    shakeTrigger,
+    handleAnswerClicked,
+  } = useGuessColorsGame();
 
   return (
     <div className="App">
       <ThemeToggle />
       <main>
         <h1>Guess Colors</h1>
-        <ColorSwatch color={color} />
+        <ScoreBoard
+          score={score}
+          streak={streak}
+          highScore={highScore}
+          bestStreak={bestStreak}
+        />
+        <ColorSwatch
+          key={shakeTrigger}
+          color={color}
+          isWrong={result === Result.Wrong}
+        />
         <AnswerOptions answers={answers} onSelect={handleAnswerClicked} />
         <ResultMessage result={result} />
       </main>

--- a/src/__tests__/app.test.jsx
+++ b/src/__tests__/app.test.jsx
@@ -5,6 +5,7 @@ import App from "../App";
 afterEach(() => {
   vi.restoreAllMocks();
   document.body.classList.remove("darkmode");
+  localStorage.clear();
 });
 
 // Queues exact Math.random values for the calls a test cares about (e.g. the
@@ -49,6 +50,102 @@ test("checks for correct answer", () => {
   fireEvent.click(getByText("#199999"));
 
   expect(queryByText("Correct!")).toBeInTheDocument();
+});
+
+test("increments score and streak across consecutive correct answers", () => {
+  mockRandomSequence(
+    0.1, // round 1 actual -> #199999
+    0.5, // round 1 distractor -> #7fffff
+    0.9, // round 1 distractor -> #e66665
+  );
+
+  const { getByText } = render(<App />);
+
+  fireEvent.click(getByText("#199999"));
+
+  expect(getByText("Score: 1")).toBeInTheDocument();
+  expect(getByText("Streak: 1")).toBeInTheDocument();
+
+  // Round 1's own shuffle consumes two cycling values before round 2 draws
+  // its colors, so round 2's actual color is #599999 (cycling[2] = 0.35).
+  fireEvent.click(getByText("#599999"));
+
+  expect(getByText("Score: 2")).toBeInTheDocument();
+  expect(getByText("Streak: 2")).toBeInTheDocument();
+});
+
+test("resets streak but keeps score after a wrong answer", () => {
+  mockRandomSequence(
+    0.1, // round 1 actual -> #199999
+    0.5, // round 1 distractor -> #7fffff
+    0.9, // round 1 distractor -> #e66665
+  );
+
+  const { getByText } = render(<App />);
+
+  fireEvent.click(getByText("#199999"));
+  expect(getByText("Streak: 1")).toBeInTheDocument();
+
+  // Round 2's actual color is #599999; #A66665 is one of its distractors.
+  fireEvent.click(getByText("#A66665"));
+
+  expect(getByText("Score: 1")).toBeInTheDocument();
+  expect(getByText("Streak: 0")).toBeInTheDocument();
+});
+
+test("persists the best score and streak across a remount, resetting the session totals", () => {
+  mockRandomSequence(
+    0.1, // actual -> #199999
+    0.5, // distractor -> #7fffff
+    0.9, // distractor -> #e66665
+  );
+
+  const { getByText, unmount } = render(<App />);
+
+  fireEvent.click(getByText("#199999"));
+  expect(getByText("Best Score: 1")).toBeInTheDocument();
+  expect(getByText("Best Streak: 1")).toBeInTheDocument();
+
+  unmount();
+
+  mockRandomSequence(0.1, 0.5, 0.9);
+  const { getByText: getByTextAgain } = render(<App />);
+
+  expect(getByTextAgain("Score: 0")).toBeInTheDocument();
+  expect(getByTextAgain("Streak: 0")).toBeInTheDocument();
+  expect(getByTextAgain("Best Score: 1")).toBeInTheDocument();
+  expect(getByTextAgain("Best Streak: 1")).toBeInTheDocument();
+});
+
+test("selects an answer with the 1/2/3 number keys", () => {
+  mockRandomSequence(
+    0.1, // actual -> #199999
+    0.5, // distractor -> #7fffff
+    0.9, // distractor -> #e66665
+  );
+
+  // The post-shuffle button order for this seed is #7FFFFF, #E66665, #199999.
+  const { queryByText } = render(<App />);
+
+  fireEvent.keyDown(window, { key: "3" });
+
+  expect(queryByText("Correct!")).toBeInTheDocument();
+});
+
+test("ignores number keys held with a modifier, and unmapped keys", () => {
+  mockRandomSequence(
+    0.1, // actual -> #199999
+    0.5, // distractor -> #7fffff
+    0.9, // distractor -> #e66665
+  );
+
+  const { queryByText } = render(<App />);
+
+  fireEvent.keyDown(window, { key: "3", ctrlKey: true });
+  fireEvent.keyDown(window, { key: "9" });
+
+  expect(queryByText("Correct!")).not.toBeInTheDocument();
+  expect(queryByText("Wrong Answer")).not.toBeInTheDocument();
 });
 
 test("checks for wrong answer", () => {

--- a/src/__tests__/stats.test.js
+++ b/src/__tests__/stats.test.js
@@ -1,0 +1,27 @@
+import { loadStats, saveStats } from "../utils/stats";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+test("returns zeroed defaults when nothing is stored", () => {
+  expect(loadStats()).toEqual({ highScore: 0, bestStreak: 0 });
+});
+
+test("returns the persisted values when present", () => {
+  saveStats({ highScore: 5, bestStreak: 3 });
+
+  expect(loadStats()).toEqual({ highScore: 5, bestStreak: 3 });
+});
+
+test("falls back to defaults when the stored value is corrupt JSON", () => {
+  localStorage.setItem("guessColors.stats", "{not valid json");
+
+  expect(loadStats()).toEqual({ highScore: 0, bestStreak: 0 });
+});
+
+test("falls back to defaults when the stored value is the wrong shape", () => {
+  localStorage.setItem("guessColors.stats", JSON.stringify({ highScore: "5" }));
+
+  expect(loadStats()).toEqual({ highScore: 0, bestStreak: 0 });
+});

--- a/src/components/AnswerOptions.tsx
+++ b/src/components/AnswerOptions.tsx
@@ -6,8 +6,13 @@ type AnswerOptionsProps = {
 export function AnswerOptions({ answers, onSelect }: AnswerOptionsProps) {
   return (
     <>
-      {answers.map((answer) => (
-        <button type="button" onClick={() => onSelect(answer)} key={answer}>
+      {answers.map((answer, index) => (
+        <button
+          type="button"
+          onClick={() => onSelect(answer)}
+          key={answer}
+          aria-keyshortcuts={String(index + 1)}
+        >
           {answer.toUpperCase()}
         </button>
       ))}

--- a/src/components/ColorSwatch.tsx
+++ b/src/components/ColorSwatch.tsx
@@ -1,12 +1,13 @@
 type ColorSwatchProps = {
   color: string;
+  isWrong: boolean;
 };
 
-export function ColorSwatch({ color }: ColorSwatchProps) {
+export function ColorSwatch({ color, isWrong }: ColorSwatchProps) {
   return (
     <div
       data-testid="guess-me"
-      className="guess-me"
+      className={isWrong ? "guess-me shake" : "guess-me"}
       style={{ background: color }}
     ></div>
   );

--- a/src/components/ScoreBoard.tsx
+++ b/src/components/ScoreBoard.tsx
@@ -1,0 +1,22 @@
+type ScoreBoardProps = {
+  score: number;
+  streak: number;
+  highScore: number;
+  bestStreak: number;
+};
+
+export function ScoreBoard({
+  score,
+  streak,
+  highScore,
+  bestStreak,
+}: ScoreBoardProps) {
+  return (
+    <div className="score-board">
+      <span>Score: {score}</span>
+      <span>Streak: {streak}</span>
+      <span>Best Score: {highScore}</span>
+      <span>Best Streak: {bestStreak}</span>
+    </div>
+  );
+}

--- a/src/hooks/useGuessColorsGame.ts
+++ b/src/hooks/useGuessColorsGame.ts
@@ -2,11 +2,18 @@ import { useCallback, useEffect, useState } from "react";
 import { Result } from "../types";
 import { shuffleArray } from "../utils/array";
 import { generateRandomColor } from "../utils/color";
+import { loadStats, saveStats } from "../utils/stats";
+
+const ANSWER_KEYS: Record<string, number> = { "1": 0, "2": 1, "3": 2 };
 
 export function useGuessColorsGame() {
   const [color, setColor] = useState("");
   const [answers, setAnswers] = useState<string[]>([]);
   const [result, setResult] = useState<Result | undefined>(undefined);
+  const [score, setScore] = useState(0);
+  const [streak, setStreak] = useState(0);
+  const [stats, setStats] = useState(() => loadStats());
+  const [shakeTrigger, setShakeTrigger] = useState(0);
 
   const generateRandomColors = useCallback(() => {
     const actualColor = generateRandomColor();
@@ -27,14 +34,64 @@ export function useGuessColorsGame() {
     generateRandomColors();
   }, [generateRandomColors]);
 
-  function handleAnswerClicked(answer: string): void {
-    if (answer === color) {
-      setResult(Result.Correct);
-      generateRandomColors();
-    } else {
-      setResult(Result.Wrong);
-    }
-  }
+  useEffect(() => {
+    setStats((prev) => {
+      const nextHighScore = Math.max(prev.highScore, score);
+      const nextBestStreak = Math.max(prev.bestStreak, streak);
+      if (
+        nextHighScore === prev.highScore &&
+        nextBestStreak === prev.bestStreak
+      ) {
+        return prev;
+      }
+      const next = { highScore: nextHighScore, bestStreak: nextBestStreak };
+      saveStats(next);
+      return next;
+    });
+  }, [score, streak]);
 
-  return { color, answers, result, handleAnswerClicked };
+  const handleAnswerClicked = useCallback(
+    (answer: string): void => {
+      if (answer === color) {
+        setResult(Result.Correct);
+        setScore((s) => s + 1);
+        setStreak((s) => s + 1);
+        generateRandomColors();
+      } else {
+        setResult(Result.Wrong);
+        setStreak(0);
+        setShakeTrigger((t) => t + 1);
+      }
+    },
+    [color, generateRandomColors],
+  );
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.ctrlKey || event.metaKey || event.altKey) return;
+
+      const index = ANSWER_KEYS[event.key];
+      if (index === undefined) return;
+
+      const answer = answers[index];
+      if (answer === undefined) return;
+
+      handleAnswerClicked(answer);
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [answers, handleAnswerClicked]);
+
+  return {
+    color,
+    answers,
+    result,
+    score,
+    streak,
+    highScore: stats.highScore,
+    bestStreak: stats.bestStreak,
+    shakeTrigger,
+    handleAnswerClicked,
+  };
 }

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -1,0 +1,36 @@
+export type Stats = {
+  highScore: number;
+  bestStreak: number;
+};
+
+const STORAGE_KEY = "guessColors.stats";
+const DEFAULT_STATS: Stats = { highScore: 0, bestStreak: 0 };
+
+export function loadStats(): Stats {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_STATS;
+
+    const parsed = JSON.parse(raw);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      typeof parsed.highScore !== "number" ||
+      typeof parsed.bestStreak !== "number"
+    ) {
+      return DEFAULT_STATS;
+    }
+
+    return { highScore: parsed.highScore, bestStreak: parsed.bestStreak };
+  } catch {
+    return DEFAULT_STATS;
+  }
+}
+
+export function saveStats(stats: Stats): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(stats));
+  } catch {
+    // Storage may be unavailable (e.g. private browsing) or full; ignore.
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1 of a Pareto-prioritized "wow features" roadmap — the highest-impact, lowest-effort additions:

- **Score and streak tracking** (`ScoreBoard`): session score/streak, plus the all-time high score and best streak persisted in `localStorage` (`src/utils/stats.ts`, corrupt-data-safe). The running score/streak reset each session; only the records survive reloads.
- **Keyboard play**: press 1, 2, or 3 to pick the corresponding answer button (ignoring Ctrl/Cmd/Alt combinations so browser shortcuts aren't hijacked).
- **Animations**: a smooth color transition on the swatch when a new round starts, and a shake effect on a wrong answer — both disabled under `prefers-reduced-motion`.

## Notable implementation details

- The shake animation is driven by a monotonically-incrementing counter used as a React `key` on `<ColorSwatch>`, not a boolean derived from the result state. React 18 bails out re-renders when a state setter is called with an unchanged value, so two consecutive wrong answers wouldn't replay a naively-derived `className` — the counter always changes, forcing a remount that reliably restarts the CSS animation.
- E2E tests needed a short wait after a correct answer before re-deriving the next round's correct/wrong buttons from the swatch's rendered color, since the new `background-color` transition (0.3s) can otherwise be caught mid-animation.
- `aria-keyshortcuts` was added to each answer button for assistive-tech discoverability of the new keyboard shortcuts (no visible on-screen number badges in this phase — an easy follow-up).

## Test plan

- [x] `pnpm run lint` — clean
- [x] `pnpm run build` — type-checks and builds cleanly
- [x] `pnpm run test:coverage` — 28/28 unit tests pass, coverage above the 90% gate (99%/97.56%/100%/100%)
- [x] `pnpm run e2e` — all 14 Playwright specs pass, including 3 new specs (score/streak tracking, keyboard play, shake/reduced-motion/reload-persistence) and the existing axe accessibility scans (no new violations)
- [x] Manual check via `pnpm run dev` + screenshots confirming the `ScoreBoard` layout and wrong-answer flow render correctly
