### PR TITLE
Add gamification and micro-interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ number, most recent first.
 
 ### Added
 
+- Gamification layer on top of the score/streak base:
+  - **XP and levels** — each correct answer awards points that fill an animated
+    level progress bar (`XpBar`); reaching a new level pops the bar and fires a
+    celebration. XP/level math lives in `src/utils/levels.ts`.
+  - **Combo multiplier** — consecutive correct answers raise a point multiplier
+    (up to ×5), surfaced as a `Combo ×N 🔥` badge and applied to XP.
+  - **Difficulty progression** — distractor colors get progressively closer to
+    the target as the level climbs (`generateDistractor` in `src/utils/color.ts`);
+    level 1 is unchanged, so the base game stays approachable.
+  - **Achievements** — unlockable badges (first win, score/streak/level
+    milestones) defined in `src/utils/achievements.ts`, announced via a toast
+    (`AchievementToast`) and persisted in `localStorage`.
+- Micro-interactions, all respecting `prefers-reduced-motion`:
+  - A **confetti burst** (`Confetti`) on correct answers.
+  - **Floating `+N ×combo` score popups** (`FloatingScore`) rising from the swatch.
+  - **Correct/wrong button flashes** on the answer options.
+  - **Sound effects** (WebAudio blips for correct/wrong/level-up/achievement) via
+    `src/utils/sound.ts`, with a persisted **mute toggle** (`SoundToggle`) beside
+    the theme toggle. Audio degrades to a safe no-op where WebAudio is
+    unavailable.
+- Persistence (`src/utils/stats.ts`) now also tracks the best level reached and
+  unlocked achievements, with backward-compatible loading of older saves.
 - A playful visual redesign built on Tailwind CSS v4: gradient page background,
   centered game card, pill-style score chips, chunky answer buttons with
   visible 1/2/3 key hints, a bundled Nunito font, and a glow on the swatch

--- a/e2e/animations.spec.ts
+++ b/e2e/animations.spec.ts
@@ -30,6 +30,75 @@ test("does not shake under prefers-reduced-motion", async ({ page }) => {
   await expect(swatch).toHaveCSS("transform", "none");
 });
 
+test("flashes the clicked button on a wrong answer", async ({ page }) => {
+  await gotoHome(page);
+
+  const { wrong } = await findAnswerButtons(page);
+  await wrong.click();
+
+  // The wrong option stays highlighted (the round continues) via data-flash.
+  await expect(wrong).toHaveAttribute("data-flash", "wrong");
+});
+
+test("awards XP and advances the level progress bar on a correct answer", async ({
+  page,
+}) => {
+  await gotoHome(page);
+
+  const bar = page.getByRole("progressbar");
+  await expect(bar).toHaveAttribute("aria-valuenow", "0");
+
+  const { correct } = await findAnswerButtons(page);
+  await correct.click();
+
+  // A correct answer awards BASE_POINTS (10) at the 1x combo.
+  await expect(bar).toHaveAttribute("aria-valuenow", "10");
+});
+
+test("bursts confetti on a correct answer, but never under reduced motion", async ({
+  page,
+}) => {
+  await gotoHome(page);
+
+  const { correct } = await findAnswerButtons(page);
+  await correct.click();
+
+  // The confetti layer is present and flips to active for the burst.
+  await expect(page.locator("[data-confetti]")).toHaveAttribute(
+    "data-confetti",
+    "active",
+  );
+});
+
+test("renders no confetti layer under reduced motion", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await gotoHome(page);
+
+  const { correct } = await findAnswerButtons(page);
+  await correct.click();
+
+  await expect(page.getByText("Correct!")).toBeVisible();
+  await expect(page.locator("[data-confetti]")).toHaveCount(0);
+});
+
+test("mutes and persists the sound preference", async ({ page }) => {
+  await gotoHome(page);
+
+  const muteButton = page.getByRole("button", { name: "Mute sounds" });
+  await expect(muteButton).toHaveAttribute("aria-pressed", "false");
+
+  await muteButton.click();
+  await expect(
+    page.getByRole("button", { name: "Unmute sounds" }),
+  ).toHaveAttribute("aria-pressed", "true");
+
+  await page.reload();
+
+  await expect(
+    page.getByRole("button", { name: "Unmute sounds" }),
+  ).toHaveAttribute("aria-pressed", "true");
+});
+
 test("persists best score and streak across a reload, resetting the session totals", async ({
   page,
 }) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,14 @@
 import { MotionConfig } from "motion/react";
+import { AchievementToast } from "./components/AchievementToast";
 import { AnswerOptions } from "./components/AnswerOptions";
 import { ColorSwatch } from "./components/ColorSwatch";
+import { Confetti } from "./components/Confetti";
+import { FloatingScore } from "./components/FloatingScore";
 import { ResultMessage } from "./components/ResultMessage";
 import { ScoreBoard } from "./components/ScoreBoard";
+import { SoundToggle } from "./components/SoundToggle";
 import { ThemeToggle } from "./components/ThemeToggle";
+import { XpBar } from "./components/XpBar";
 import { useGuessColorsGame } from "./hooks/useGuessColorsGame";
 
 function App() {
@@ -13,9 +18,16 @@ function App() {
     result,
     score,
     streak,
+    comboMultiplier,
+    levelProgress,
     highScore,
     bestStreak,
     shakeTrigger,
+    confettiTrigger,
+    levelUpTrigger,
+    pointsAwarded,
+    lastAnswer,
+    earnedAchievement,
     handleAnswerClicked,
   } = useGuessColorsGame();
 
@@ -23,20 +35,32 @@ function App() {
     <MotionConfig reducedMotion="user">
       <div className="flex min-h-full items-center justify-center bg-linear-to-br from-violet-200 via-sky-100 to-amber-100 p-4 font-sans text-slate-900 dark:from-slate-950 dark:via-indigo-950 dark:to-slate-900 dark:text-slate-100">
         <ThemeToggle />
-        <main className="flex w-full max-w-md flex-col items-center gap-5 rounded-3xl bg-white p-6 shadow-2xl ring-1 ring-slate-900/5 sm:p-8 dark:bg-slate-800 dark:ring-white/10">
+        <SoundToggle />
+        <main className="relative flex w-full max-w-md flex-col items-center gap-5 rounded-3xl bg-white p-6 shadow-2xl ring-1 ring-slate-900/5 sm:p-8 dark:bg-slate-800 dark:ring-white/10">
+          <Confetti trigger={confettiTrigger} />
           <h1 className="text-3xl font-extrabold tracking-tight">
             Guess Colors
           </h1>
+          <XpBar progress={levelProgress} levelUpTrigger={levelUpTrigger} />
           <ScoreBoard
             score={score}
             streak={streak}
             highScore={highScore}
             bestStreak={bestStreak}
+            comboMultiplier={comboMultiplier}
           />
-          <ColorSwatch color={color} shakeTrigger={shakeTrigger} />
-          <AnswerOptions answers={answers} onSelect={handleAnswerClicked} />
+          <div className="relative w-full">
+            <ColorSwatch color={color} shakeTrigger={shakeTrigger} />
+            <FloatingScore points={pointsAwarded} />
+          </div>
+          <AnswerOptions
+            answers={answers}
+            lastAnswer={lastAnswer}
+            onSelect={handleAnswerClicked}
+          />
           <ResultMessage result={result} />
         </main>
+        <AchievementToast achievement={earnedAchievement} />
       </div>
     </MotionConfig>
   );

--- a/src/__tests__/AchievementToast.test.jsx
+++ b/src/__tests__/AchievementToast.test.jsx
@@ -1,0 +1,28 @@
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { AchievementToast } from "../components/AchievementToast";
+
+const achievement = {
+  id: "first-win",
+  label: "First Win",
+  emoji: "🎯",
+  description: "Guess your first color.",
+  isUnlocked: () => true,
+  nonce: 1,
+};
+
+test("renders no toast content when there is no achievement", () => {
+  const { container } = render(<AchievementToast achievement={null} />);
+  expect(container.textContent).not.toContain("Achievement unlocked");
+});
+
+test("announces a newly unlocked achievement", () => {
+  const { getByText, rerender } = render(
+    <AchievementToast achievement={null} />,
+  );
+
+  rerender(<AchievementToast achievement={achievement} />);
+
+  expect(getByText("Achievement unlocked")).toBeInTheDocument();
+  expect(getByText("First Win")).toBeInTheDocument();
+});

--- a/src/__tests__/Confetti.test.jsx
+++ b/src/__tests__/Confetti.test.jsx
@@ -1,0 +1,29 @@
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Confetti } from "../components/Confetti";
+import { setPrefersReducedMotion } from "../test/setup";
+
+test("renders an idle container before any trigger", () => {
+  const { container } = render(<Confetti trigger={0} />);
+  const root = container.querySelector("[data-confetti]");
+  expect(root).toHaveAttribute("data-confetti", "idle");
+});
+
+test("emits a particle burst when the trigger increments", () => {
+  const { container, rerender } = render(<Confetti trigger={0} />);
+
+  rerender(<Confetti trigger={1} />);
+
+  const root = container.querySelector("[data-confetti]");
+  expect(root).toHaveAttribute("data-confetti", "active");
+  expect(root.querySelectorAll("span").length).toBeGreaterThan(0);
+});
+
+test("renders nothing under reduced motion", () => {
+  setPrefersReducedMotion(true);
+  const { container, rerender } = render(<Confetti trigger={0} />);
+
+  rerender(<Confetti trigger={1} />);
+
+  expect(container.querySelector("[data-confetti]")).toBeNull();
+});

--- a/src/__tests__/FloatingScore.test.jsx
+++ b/src/__tests__/FloatingScore.test.jsx
@@ -1,0 +1,26 @@
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { FloatingScore } from "../components/FloatingScore";
+
+test("renders nothing when there are no points", () => {
+  const { container } = render(<FloatingScore points={null} />);
+  expect(container.textContent).toBe("");
+});
+
+test("shows the awarded points with the combo multiplier", () => {
+  const { container, rerender } = render(<FloatingScore points={null} />);
+
+  rerender(<FloatingScore points={{ value: 30, multiplier: 3, id: 1 }} />);
+
+  expect(container.textContent).toContain("+30");
+  expect(container.textContent).toContain("×3");
+});
+
+test("omits the multiplier at 1x", () => {
+  const { container, rerender } = render(<FloatingScore points={null} />);
+
+  rerender(<FloatingScore points={{ value: 10, multiplier: 1, id: 2 }} />);
+
+  expect(container.textContent).toContain("+10");
+  expect(container.textContent).not.toContain("×");
+});

--- a/src/__tests__/ScoreBoard.test.jsx
+++ b/src/__tests__/ScoreBoard.test.jsx
@@ -4,13 +4,45 @@ import { ScoreBoard } from "../components/ScoreBoard";
 
 test("renders all four stats with exact labels", () => {
   const { getByText } = render(
-    <ScoreBoard score={3} streak={2} highScore={7} bestStreak={4} />,
+    <ScoreBoard
+      score={3}
+      streak={2}
+      highScore={7}
+      bestStreak={4}
+      comboMultiplier={1}
+    />,
   );
 
   expect(getByText("Score: 3")).toBeInTheDocument();
   expect(getByText("Streak: 2")).toBeInTheDocument();
   expect(getByText("Best Score: 7")).toBeInTheDocument();
   expect(getByText("Best Streak: 4")).toBeInTheDocument();
+});
+
+test("shows a combo badge only when the multiplier exceeds one", () => {
+  const { queryByText, rerender } = render(
+    <ScoreBoard
+      score={2}
+      streak={2}
+      highScore={2}
+      bestStreak={2}
+      comboMultiplier={1}
+    />,
+  );
+
+  expect(queryByText(/Combo/)).not.toBeInTheDocument();
+
+  rerender(
+    <ScoreBoard
+      score={3}
+      streak={3}
+      highScore={3}
+      bestStreak={3}
+      comboMultiplier={2}
+    />,
+  );
+
+  expect(queryByText("Combo ×2", { exact: false })).toBeInTheDocument();
 });
 
 test("celebrates streak milestones with a flame, but not other streaks", () => {

--- a/src/__tests__/SoundToggle.test.jsx
+++ b/src/__tests__/SoundToggle.test.jsx
@@ -1,0 +1,27 @@
+import { fireEvent, render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { SoundToggle } from "../components/SoundToggle";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+test("toggles mute state and persists it", () => {
+  const { getByRole } = render(<SoundToggle />);
+  const button = getByRole("button");
+
+  expect(button).toHaveAttribute("aria-pressed", "false");
+
+  fireEvent.click(button);
+  expect(button).toHaveAttribute("aria-pressed", "true");
+  expect(localStorage.getItem("guessColors.muted")).toBe("true");
+
+  fireEvent.click(button);
+  expect(button).toHaveAttribute("aria-pressed", "false");
+  expect(localStorage.getItem("guessColors.muted")).toBe("false");
+});
+
+test("exposes an accessible label", () => {
+  const { getByText } = render(<SoundToggle />);
+  expect(getByText("Mute sounds")).toBeInTheDocument();
+});

--- a/src/__tests__/XpBar.test.jsx
+++ b/src/__tests__/XpBar.test.jsx
@@ -1,0 +1,39 @@
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { XpBar } from "../components/XpBar";
+import { setPrefersReducedMotion } from "../test/setup";
+
+test("renders the level label and progressbar aria values", () => {
+  const progress = { level: 2, into: 10, needed: 40, ratio: 0.25 };
+  const { getByRole, getByText } = render(
+    <XpBar progress={progress} levelUpTrigger={0} />,
+  );
+
+  expect(getByText("Level 2")).toBeInTheDocument();
+
+  const bar = getByRole("progressbar");
+  expect(bar).toHaveAttribute("aria-valuenow", "10");
+  expect(bar).toHaveAttribute("aria-valuemax", "40");
+  expect(bar).toHaveAttribute("aria-valuemin", "0");
+});
+
+test("keeps rendering when a level-up flash is triggered", () => {
+  const progress = { level: 3, into: 0, needed: 50, ratio: 0 };
+  const { getByRole, rerender } = render(
+    <XpBar progress={progress} levelUpTrigger={0} />,
+  );
+
+  rerender(<XpBar progress={progress} levelUpTrigger={1} />);
+  expect(getByRole("progressbar")).toBeInTheDocument();
+});
+
+test("does not flash under reduced motion", () => {
+  setPrefersReducedMotion(true);
+  const progress = { level: 4, into: 5, needed: 60, ratio: 0.08 };
+  const { getByRole, rerender } = render(
+    <XpBar progress={progress} levelUpTrigger={0} />,
+  );
+
+  rerender(<XpBar progress={progress} levelUpTrigger={1} />);
+  expect(getByRole("progressbar")).toBeInTheDocument();
+});

--- a/src/__tests__/achievements.test.js
+++ b/src/__tests__/achievements.test.js
@@ -1,0 +1,45 @@
+import {
+  ACHIEVEMENTS,
+  evaluateNewUnlocks,
+  getAchievement,
+} from "../utils/achievements";
+
+const baseCtx = { score: 0, streak: 0, bestStreak: 0, level: 1 };
+
+test("every achievement has the required shape", () => {
+  for (const achievement of ACHIEVEMENTS) {
+    expect(typeof achievement.id).toBe("string");
+    expect(typeof achievement.label).toBe("string");
+    expect(typeof achievement.emoji).toBe("string");
+    expect(typeof achievement.isUnlocked).toBe("function");
+  }
+});
+
+test("getAchievement looks up by id", () => {
+  expect(getAchievement("first-win")?.label).toBe("First Win");
+  expect(getAchievement("nope")).toBeUndefined();
+});
+
+test("first win unlocks on the first correct answer", () => {
+  const unlocks = evaluateNewUnlocks({ ...baseCtx, score: 1 }, []);
+  expect(unlocks).toContain("first-win");
+});
+
+test("does not re-report already-unlocked achievements", () => {
+  const unlocks = evaluateNewUnlocks({ ...baseCtx, score: 1 }, ["first-win"]);
+  expect(unlocks).not.toContain("first-win");
+});
+
+test("score, streak, and level thresholds each unlock their badge", () => {
+  expect(evaluateNewUnlocks({ ...baseCtx, score: 10 }, [])).toContain(
+    "score-10",
+  );
+  expect(evaluateNewUnlocks({ ...baseCtx, bestStreak: 5 }, [])).toContain(
+    "streak-5",
+  );
+  expect(evaluateNewUnlocks({ ...baseCtx, level: 3 }, [])).toContain("level-3");
+});
+
+test("returns nothing when no thresholds are met", () => {
+  expect(evaluateNewUnlocks(baseCtx, [])).toEqual([]);
+});

--- a/src/__tests__/color.test.js
+++ b/src/__tests__/color.test.js
@@ -1,4 +1,4 @@
-import { generateRandomColor } from "../utils/color";
+import { generateDistractor, generateRandomColor } from "../utils/color";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -32,5 +32,32 @@ test("always generates vivid colors visible on light and dark backgrounds", () =
     // (never near-black) and real chroma spread (never near-white or gray).
     expect(max).toBeGreaterThanOrEqual(160);
     expect(max - min).toBeGreaterThanOrEqual(90);
+  }
+});
+
+test("generateDistractor at difficulty 0 ignores the target and matches the base generator", () => {
+  vi.spyOn(Math, "random").mockReturnValue(0.1);
+
+  // Same single draw as generateRandomColor -> same result, target unused.
+  expect(generateDistractor("#ffffff", 0)).toBe("#e09e3b");
+});
+
+test("generateDistractor at higher difficulty stays a valid vivid color", () => {
+  const target = generateRandomColor();
+
+  for (let i = 0; i < 200; i++) {
+    const difficulty = 1 + (i % 6);
+    const color = generateDistractor(target, difficulty);
+    expect(color).toMatch(/^#[0-9a-f]{6}$/);
+
+    const channels = [1, 3, 5].map((offset) =>
+      Number.parseInt(color.slice(offset, offset + 2), 16),
+    );
+    const max = Math.max(...channels);
+    const min = Math.min(...channels);
+
+    // Clamped to the same vivid gamut as the target swatch.
+    expect(max).toBeGreaterThanOrEqual(150);
+    expect(max - min).toBeGreaterThanOrEqual(70);
   }
 });

--- a/src/__tests__/levels.test.js
+++ b/src/__tests__/levels.test.js
@@ -1,0 +1,52 @@
+import {
+  BASE_POINTS,
+  getComboMultiplier,
+  getLevel,
+  getLevelProgress,
+  xpForLevel,
+} from "../utils/levels";
+
+test("combo multiplier climbs every third streak, capped at 5", () => {
+  expect(getComboMultiplier(0)).toBe(1);
+  expect(getComboMultiplier(1)).toBe(1);
+  expect(getComboMultiplier(2)).toBe(1);
+  expect(getComboMultiplier(3)).toBe(2);
+  expect(getComboMultiplier(5)).toBe(2);
+  expect(getComboMultiplier(6)).toBe(3);
+  expect(getComboMultiplier(9)).toBe(4);
+  expect(getComboMultiplier(12)).toBe(5);
+  expect(getComboMultiplier(100)).toBe(5);
+});
+
+test("xpForLevel starts at 0 and increases per level", () => {
+  expect(xpForLevel(1)).toBe(0);
+  expect(xpForLevel(0)).toBe(0);
+  expect(xpForLevel(2)).toBe(30);
+  expect(xpForLevel(3)).toBe(70);
+  expect(xpForLevel(4)).toBeGreaterThan(xpForLevel(3));
+});
+
+test("two base-point answers stay at level 1 (protects seeded tests)", () => {
+  // First two correct answers award BASE_POINTS each (combo 1x).
+  expect(getLevel(BASE_POINTS * 2)).toBe(1);
+  expect(getLevel(0)).toBe(1);
+});
+
+test("getLevel advances once the cumulative threshold is met", () => {
+  expect(getLevel(xpForLevel(2))).toBe(2);
+  expect(getLevel(xpForLevel(2) - 1)).toBe(1);
+  expect(getLevel(xpForLevel(3))).toBe(3);
+});
+
+test("getLevelProgress reports position within the current level", () => {
+  const atFloor = getLevelProgress(xpForLevel(2));
+  expect(atFloor.level).toBe(2);
+  expect(atFloor.into).toBe(0);
+  expect(atFloor.ratio).toBe(0);
+
+  const midway = getLevelProgress(xpForLevel(2) + 5);
+  expect(midway.level).toBe(2);
+  expect(midway.into).toBe(5);
+  expect(midway.needed).toBe(xpForLevel(3) - xpForLevel(2));
+  expect(midway.ratio).toBeCloseTo(5 / midway.needed);
+});

--- a/src/__tests__/sound.test.js
+++ b/src/__tests__/sound.test.js
@@ -1,0 +1,93 @@
+import { isMuted, playSound, setMuted } from "../utils/sound";
+
+class FakeGain {
+  constructor() {
+    this.gain = {
+      setValueAtTime: vi.fn(),
+      exponentialRampToValueAtTime: vi.fn(),
+    };
+  }
+  connect() {}
+}
+
+class FakeOscillator {
+  constructor() {
+    this.frequency = { value: 0 };
+    this.type = "sine";
+  }
+  connect() {}
+  start() {}
+  stop() {}
+}
+
+class FakeAudioContext {
+  constructor() {
+    this.state = "suspended";
+    this.currentTime = 0;
+    this.destination = {};
+    this.resume = vi.fn();
+    this.createOscillator = vi.fn(() => new FakeOscillator());
+    this.createGain = vi.fn(() => new FakeGain());
+  }
+}
+
+afterEach(() => {
+  localStorage.clear();
+  setMuted(false);
+  delete window.AudioContext;
+});
+
+test("mute state defaults to off and persists when toggled", () => {
+  expect(isMuted()).toBe(false);
+
+  setMuted(true);
+  expect(isMuted()).toBe(true);
+  expect(localStorage.getItem("guessColors.muted")).toBe("true");
+
+  setMuted(false);
+  expect(isMuted()).toBe(false);
+});
+
+test("playSound is a no-op when WebAudio is unavailable", () => {
+  // jsdom exposes no AudioContext, so this must not throw.
+  expect(() => playSound("correct")).not.toThrow();
+});
+
+test("playSound does nothing while muted", () => {
+  window.AudioContext = FakeAudioContext;
+  setMuted(true);
+
+  playSound("correct");
+
+  // No context is constructed because we bail out before touching audio.
+  expect(FakeAudioContext.prototype).toBeDefined();
+});
+
+test("playSound builds oscillator tones when audio is available", () => {
+  const instances = [];
+  class Spied extends FakeAudioContext {
+    constructor() {
+      super();
+      instances.push(this);
+    }
+  }
+  window.AudioContext = Spied;
+  setMuted(false);
+
+  playSound("correct");
+
+  expect(instances.length).toBeGreaterThan(0);
+  const ctx = instances[0];
+  expect(ctx.resume).toHaveBeenCalled();
+  expect(ctx.createOscillator).toHaveBeenCalled();
+  expect(ctx.createGain).toHaveBeenCalled();
+});
+
+test("every sound kind plays without error", () => {
+  window.AudioContext = FakeAudioContext;
+  setMuted(false);
+
+  for (const kind of ["correct", "wrong", "levelUp", "achievement"]) {
+    expect(() => playSound(kind)).not.toThrow();
+  }
+});

--- a/src/__tests__/stats.test.js
+++ b/src/__tests__/stats.test.js
@@ -1,27 +1,73 @@
 import { loadStats, saveStats } from "../utils/stats";
 
+const DEFAULTS = {
+  highScore: 0,
+  bestStreak: 0,
+  bestLevel: 1,
+  unlockedAchievements: [],
+};
+
 afterEach(() => {
   localStorage.clear();
 });
 
 test("returns zeroed defaults when nothing is stored", () => {
-  expect(loadStats()).toEqual({ highScore: 0, bestStreak: 0 });
+  expect(loadStats()).toEqual(DEFAULTS);
 });
 
 test("returns the persisted values when present", () => {
-  saveStats({ highScore: 5, bestStreak: 3 });
+  const stats = {
+    highScore: 5,
+    bestStreak: 3,
+    bestLevel: 4,
+    unlockedAchievements: ["first-win", "streak-5"],
+  };
+  saveStats(stats);
 
-  expect(loadStats()).toEqual({ highScore: 5, bestStreak: 3 });
+  expect(loadStats()).toEqual(stats);
 });
 
 test("falls back to defaults when the stored value is corrupt JSON", () => {
   localStorage.setItem("guessColors.stats", "{not valid json");
 
-  expect(loadStats()).toEqual({ highScore: 0, bestStreak: 0 });
+  expect(loadStats()).toEqual(DEFAULTS);
 });
 
 test("falls back to defaults when the stored value is the wrong shape", () => {
   localStorage.setItem("guessColors.stats", JSON.stringify({ highScore: "5" }));
 
-  expect(loadStats()).toEqual({ highScore: 0, bestStreak: 0 });
+  expect(loadStats()).toEqual(DEFAULTS);
+});
+
+test("migrates an older save that predates bestLevel/achievements", () => {
+  localStorage.setItem(
+    "guessColors.stats",
+    JSON.stringify({ highScore: 7, bestStreak: 4 }),
+  );
+
+  expect(loadStats()).toEqual({
+    highScore: 7,
+    bestStreak: 4,
+    bestLevel: 1,
+    unlockedAchievements: [],
+  });
+});
+
+test("ignores an invalid unlockedAchievements array", () => {
+  localStorage.setItem(
+    "guessColors.stats",
+    JSON.stringify({
+      highScore: 2,
+      bestStreak: 1,
+      bestLevel: 2,
+      unlockedAchievements: [1, "first-win"],
+    }),
+  );
+
+  expect(loadStats()).toEqual({
+    highScore: 2,
+    bestStreak: 1,
+    bestLevel: 2,
+    unlockedAchievements: [],
+  });
 });

--- a/src/components/AchievementToast.tsx
+++ b/src/components/AchievementToast.tsx
@@ -1,0 +1,51 @@
+import { AnimatePresence, motion } from "motion/react";
+import { useEffect, useState } from "react";
+import type { EarnedAchievement } from "../hooks/useGuessColorsGame";
+
+type AchievementToastProps = {
+  achievement: EarnedAchievement | null;
+};
+
+// A transient toast announcing a newly unlocked badge. Auto-dismisses; the
+// live region announces it to screen readers.
+export function AchievementToast({ achievement }: AchievementToastProps) {
+  const [current, setCurrent] = useState<EarnedAchievement | null>(null);
+
+  useEffect(() => {
+    if (!achievement) return;
+    setCurrent(achievement);
+    const timeout = setTimeout(() => setCurrent(null), 3200);
+    return () => clearTimeout(timeout);
+  }, [achievement]);
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="pointer-events-none fixed inset-x-0 bottom-6 z-30 flex justify-center px-4"
+    >
+      <AnimatePresence>
+        {current && (
+          <motion.div
+            key={current.nonce}
+            initial={{ y: 40, opacity: 0, scale: 0.9 }}
+            animate={{ y: 0, opacity: 1, scale: 1 }}
+            exit={{ y: 20, opacity: 0 }}
+            transition={{ type: "spring", stiffness: 400, damping: 26 }}
+            className="flex items-center gap-3 rounded-2xl bg-slate-900 px-4 py-3 text-white shadow-2xl ring-1 ring-white/10 dark:bg-slate-100 dark:text-slate-900"
+          >
+            <span aria-hidden="true" className="text-2xl">
+              {current.emoji}
+            </span>
+            <span className="flex flex-col leading-tight">
+              <span className="text-xs font-semibold tracking-wide uppercase opacity-70">
+                Achievement unlocked
+              </span>
+              <span className="font-extrabold">{current.label}</span>
+            </span>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/components/AnswerOptions.tsx
+++ b/src/components/AnswerOptions.tsx
@@ -1,36 +1,73 @@
 import { motion } from "motion/react";
+import type { LastAnswer } from "../hooks/useGuessColorsGame";
 
 type AnswerOptionsProps = {
   answers: string[];
+  lastAnswer: LastAnswer | null;
   onSelect: (answer: string) => void;
 };
 
 const buttonSpring = { type: "spring", stiffness: 500, damping: 25 } as const;
 
-export function AnswerOptions({ answers, onSelect }: AnswerOptionsProps) {
+const baseButton =
+  "flex-1 cursor-pointer rounded-2xl border-b-4 px-4 py-3 font-bold tracking-wide shadow-sm outline-none focus-visible:ring-4";
+
+const idleButton =
+  "border-violet-300 bg-violet-100 text-slate-900 focus-visible:ring-violet-500 dark:border-violet-950 dark:bg-slate-700 dark:text-slate-100 dark:focus-visible:ring-violet-400";
+
+const correctButton =
+  "border-green-500 bg-green-200 text-green-950 focus-visible:ring-green-500 dark:border-green-400 dark:bg-green-500 dark:text-green-950";
+
+const wrongButton =
+  "border-rose-500 bg-rose-200 text-rose-950 focus-visible:ring-rose-500 dark:border-rose-400 dark:bg-rose-500 dark:text-rose-950";
+
+export function AnswerOptions({
+  answers,
+  lastAnswer,
+  onSelect,
+}: AnswerOptionsProps) {
   return (
     <div className="flex w-full flex-col gap-3 sm:flex-row">
-      {answers.map((answer, index) => (
-        <motion.button
-          type="button"
-          onClick={() => onSelect(answer)}
-          key={answer}
-          aria-keyshortcuts={String(index + 1)}
-          whileHover={{ y: -3 }}
-          whileTap={{ scale: 0.92 }}
-          transition={buttonSpring}
-          className="flex-1 cursor-pointer rounded-2xl border-b-4 border-violet-300 bg-violet-100 px-4 py-3 font-bold tracking-wide text-slate-900 shadow-sm outline-none focus-visible:ring-4 focus-visible:ring-violet-500 dark:border-violet-950 dark:bg-slate-700 dark:text-slate-100 dark:focus-visible:ring-violet-400"
-        >
-          {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: the <kbd> hint is decorative and not focusable; hiding it keeps the button's accessible name exactly the hex label */}
-          <kbd
-            aria-hidden="true"
-            className="mr-2 rounded-md bg-white/80 px-1.5 py-0.5 text-xs font-semibold text-slate-500 dark:bg-slate-900/60 dark:text-slate-400"
+      {answers.map((answer, index) => {
+        const flashed = lastAnswer?.answer === answer;
+        const flashCorrect = flashed && lastAnswer?.correct;
+        const flashWrong = flashed && lastAnswer && !lastAnswer.correct;
+        const stateClass = flashCorrect
+          ? correctButton
+          : flashWrong
+            ? wrongButton
+            : idleButton;
+
+        return (
+          <motion.button
+            type="button"
+            onClick={() => onSelect(answer)}
+            key={answer}
+            aria-keyshortcuts={String(index + 1)}
+            data-flash={
+              flashCorrect ? "correct" : flashWrong ? "wrong" : "none"
+            }
+            whileHover={{ y: -3 }}
+            whileTap={{ scale: 0.92 }}
+            animate={
+              flashed
+                ? { scale: [1, flashCorrect ? 1.06 : 0.97, 1] }
+                : { scale: 1 }
+            }
+            transition={buttonSpring}
+            className={`${baseButton} ${stateClass}`}
           >
-            {index + 1}
-          </kbd>
-          {answer.toUpperCase()}
-        </motion.button>
-      ))}
+            {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: the <kbd> hint is decorative and not focusable; hiding it keeps the button's accessible name exactly the hex label */}
+            <kbd
+              aria-hidden="true"
+              className="mr-2 rounded-md bg-white/80 px-1.5 py-0.5 text-xs font-semibold text-slate-500 dark:bg-slate-900/60 dark:text-slate-400"
+            >
+              {index + 1}
+            </kbd>
+            {answer.toUpperCase()}
+          </motion.button>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/Confetti.tsx
+++ b/src/components/Confetti.tsx
@@ -1,0 +1,94 @@
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { useEffect, useState } from "react";
+
+const COLORS = [
+  "#f43f5e",
+  "#f59e0b",
+  "#22c55e",
+  "#3b82f6",
+  "#a855f7",
+  "#ec4899",
+];
+const PARTICLE_COUNT = 16;
+
+type Particle = {
+  x: number;
+  y: number;
+  rotate: number;
+  color: string;
+  delay: number;
+};
+
+type Burst = { id: number; particles: Particle[] };
+
+function makeParticles(): Particle[] {
+  return Array.from({ length: PARTICLE_COUNT }, (_, i) => {
+    const angle = (i / PARTICLE_COUNT) * Math.PI * 2 + Math.random() * 0.6;
+    const distance = 70 + Math.random() * 90;
+    return {
+      x: Math.cos(angle) * distance,
+      y: Math.sin(angle) * distance,
+      rotate: Math.random() * 360 - 180,
+      color: COLORS[i % COLORS.length],
+      delay: Math.random() * 0.08,
+    };
+  });
+}
+
+type ConfettiProps = {
+  trigger: number;
+};
+
+// A one-shot particle burst radiating from the center of its (relatively
+// positioned) parent. Re-fires whenever `trigger` changes. Renders nothing
+// under prefers-reduced-motion.
+export function Confetti({ trigger }: ConfettiProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const [burst, setBurst] = useState<Burst | null>(null);
+
+  useEffect(() => {
+    if (trigger === 0 || prefersReducedMotion) return;
+    setBurst({ id: trigger, particles: makeParticles() });
+  }, [trigger, prefersReducedMotion]);
+
+  if (prefersReducedMotion) return null;
+
+  return (
+    <div
+      data-confetti={burst ? "active" : "idle"}
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 z-20 overflow-hidden"
+    >
+      <AnimatePresence>
+        {burst && (
+          <div key={burst.id} className="absolute top-1/2 left-1/2">
+            {burst.particles.map((particle, index) => (
+              <motion.span
+                // biome-ignore lint/suspicious/noArrayIndexKey: particles are a fixed positional burst, never reordered
+                key={index}
+                className="absolute block size-2 rounded-[2px]"
+                style={{ backgroundColor: particle.color }}
+                initial={{ x: 0, y: 0, opacity: 1, scale: 1, rotate: 0 }}
+                animate={{
+                  x: particle.x,
+                  y: particle.y,
+                  opacity: 0,
+                  scale: 0.5,
+                  rotate: particle.rotate,
+                }}
+                transition={{
+                  duration: 0.8,
+                  delay: particle.delay,
+                  ease: "easeOut",
+                }}
+                onAnimationComplete={
+                  index === 0 ? () => setBurst(null) : undefined
+                }
+              />
+            ))}
+          </div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/components/FloatingScore.tsx
+++ b/src/components/FloatingScore.tsx
@@ -1,0 +1,50 @@
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { useEffect, useState } from "react";
+import type { PointsAwarded } from "../hooks/useGuessColorsGame";
+
+type FloatingScoreProps = {
+  points: PointsAwarded | null;
+};
+
+// A "+N" (with the combo multiplier when active) that floats up from the top of
+// the swatch and fades on each correct answer.
+export function FloatingScore({ points }: FloatingScoreProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const [visible, setVisible] = useState<PointsAwarded | null>(null);
+
+  useEffect(() => {
+    if (!points) return;
+    setVisible(points);
+    const timeout = setTimeout(() => setVisible(null), 900);
+    return () => clearTimeout(timeout);
+  }, [points]);
+
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-x-0 top-2 z-20 flex justify-center"
+    >
+      <AnimatePresence>
+        {visible && (
+          <motion.div
+            key={visible.id}
+            initial={{ y: 0, opacity: 0, scale: 0.6 }}
+            animate={{
+              y: prefersReducedMotion ? 0 : -32,
+              opacity: 1,
+              scale: 1,
+            }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.5, ease: "easeOut" }}
+            className="rounded-full bg-green-600/90 px-3 py-1 text-sm font-extrabold text-white shadow-lg"
+          >
+            +{visible.value}
+            {visible.multiplier > 1 && (
+              <span className="ml-1 text-amber-200">×{visible.multiplier}</span>
+            )}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/components/ScoreBoard.tsx
+++ b/src/components/ScoreBoard.tsx
@@ -6,6 +6,7 @@ type ScoreBoardProps = {
   streak: number;
   highScore: number;
   bestStreak: number;
+  comboMultiplier: number;
 };
 
 const chipSpring = { type: "spring", stiffness: 500, damping: 20 } as const;
@@ -18,6 +19,7 @@ export function ScoreBoard({
   streak,
   highScore,
   bestStreak,
+  comboMultiplier,
 }: ScoreBoardProps) {
   const previousHighScore = useRef(highScore);
   const previousBestStreak = useRef(bestStreak);
@@ -82,6 +84,18 @@ export function ScoreBoard({
       >
         Best Streak: {bestStreak}
       </motion.span>
+      {comboMultiplier > 1 && (
+        <motion.span
+          key={`combo-${comboMultiplier}`}
+          initial={{ scale: 1.4 }}
+          animate={{ scale: 1 }}
+          transition={chipSpring}
+          className={`${baseChip} col-span-2 bg-fuchsia-200 text-fuchsia-950 dark:bg-fuchsia-500 dark:text-fuchsia-950`}
+        >
+          Combo ×{comboMultiplier}
+          <span aria-hidden="true"> 🔥</span>
+        </motion.span>
+      )}
     </div>
   );
 }

--- a/src/components/SoundToggle.tsx
+++ b/src/components/SoundToggle.tsx
@@ -1,0 +1,24 @@
+import { useState } from "react";
+import { isMuted, setMuted } from "../utils/sound";
+
+export function SoundToggle() {
+  const [muted, setMutedState] = useState(() => isMuted());
+
+  function toggleMuted() {
+    const next = !muted;
+    setMuted(next);
+    setMutedState(next);
+  }
+
+  return (
+    <button
+      type="button"
+      className="fixed top-4 right-20 z-10 grid size-12 cursor-pointer place-items-center rounded-full bg-white text-xl shadow-lg ring-1 ring-slate-900/10 transition hover:scale-110 focus-visible:ring-4 focus-visible:ring-violet-500 motion-reduce:transition-none dark:bg-slate-800 dark:ring-white/20"
+      aria-pressed={muted}
+      onClick={toggleMuted}
+    >
+      <span aria-hidden="true">{muted ? "🔇" : "🔊"}</span>
+      <span className="sr-only">{muted ? "Unmute sounds" : "Mute sounds"}</span>
+    </button>
+  );
+}

--- a/src/components/XpBar.tsx
+++ b/src/components/XpBar.tsx
@@ -1,0 +1,57 @@
+import { motion, useAnimationControls, useReducedMotion } from "motion/react";
+import { useEffect } from "react";
+import type { LevelProgress } from "../utils/levels";
+
+type XpBarProps = {
+  progress: LevelProgress;
+  levelUpTrigger: number;
+};
+
+// The level + XP progress bar. The fill springs toward the current ratio, and
+// the whole bar gives a quick pop when the player levels up.
+export function XpBar({ progress, levelUpTrigger }: XpBarProps) {
+  const controls = useAnimationControls();
+  const prefersReducedMotion = useReducedMotion();
+  const percent = Math.round(progress.ratio * 100);
+
+  useEffect(() => {
+    if (levelUpTrigger === 0 || prefersReducedMotion) return;
+    controls.start({
+      scale: [1, 1.06, 1],
+      transition: { duration: 0.4, ease: "easeInOut" },
+    });
+  }, [levelUpTrigger, prefersReducedMotion, controls]);
+
+  return (
+    <motion.div animate={controls} className="w-full">
+      <div className="mb-1 flex items-center justify-between text-xs font-bold text-slate-600 dark:text-slate-300">
+        <motion.span
+          key={`level-${progress.level}`}
+          initial={{ scale: 1.3 }}
+          animate={{ scale: 1 }}
+          transition={{ type: "spring", stiffness: 500, damping: 20 }}
+        >
+          Level {progress.level}
+        </motion.span>
+        <span>
+          {progress.into} / {progress.needed} XP
+        </span>
+      </div>
+      <div
+        role="progressbar"
+        aria-label={`Level ${progress.level} progress`}
+        aria-valuemin={0}
+        aria-valuemax={progress.needed}
+        aria-valuenow={progress.into}
+        className="h-3 w-full overflow-hidden rounded-full bg-slate-200 dark:bg-slate-700"
+      >
+        <motion.div
+          className="h-full rounded-full bg-linear-to-r from-violet-500 to-fuchsia-500"
+          initial={false}
+          animate={{ width: `${percent}%` }}
+          transition={{ type: "spring", stiffness: 200, damping: 30 }}
+        />
+      </div>
+    </motion.div>
+  );
+}

--- a/src/hooks/useGuessColorsGame.ts
+++ b/src/hooks/useGuessColorsGame.ts
@@ -1,10 +1,22 @@
-import { useCallback, useEffect, useState } from "react";
-import { Result } from "../types";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { type Achievement, Result } from "../types";
+import { evaluateNewUnlocks, getAchievement } from "../utils/achievements";
 import { shuffleArray } from "../utils/array";
-import { generateRandomColor } from "../utils/color";
+import { generateDistractor, generateRandomColor } from "../utils/color";
+import {
+  BASE_POINTS,
+  getComboMultiplier,
+  getLevel,
+  getLevelProgress,
+} from "../utils/levels";
+import { playSound } from "../utils/sound";
 import { loadStats, saveStats } from "../utils/stats";
 
 const ANSWER_KEYS: Record<string, number> = { "1": 0, "2": 1, "3": 2 };
+
+export type PointsAwarded = { value: number; multiplier: number; id: number };
+export type LastAnswer = { answer: string; correct: boolean; id: number };
+export type EarnedAchievement = Achievement & { id: string; nonce: number };
 
 export function useGuessColorsGame() {
   const [color, setColor] = useState("");
@@ -12,15 +24,32 @@ export function useGuessColorsGame() {
   const [result, setResult] = useState<Result | undefined>(undefined);
   const [score, setScore] = useState(0);
   const [streak, setStreak] = useState(0);
+  const [xp, setXp] = useState(0);
   const [stats, setStats] = useState(() => loadStats());
   const [shakeTrigger, setShakeTrigger] = useState(0);
+  const [confettiTrigger, setConfettiTrigger] = useState(0);
+  const [levelUpTrigger, setLevelUpTrigger] = useState(0);
+  const [pointsAwarded, setPointsAwarded] = useState<PointsAwarded | null>(
+    null,
+  );
+  const [lastAnswer, setLastAnswer] = useState<LastAnswer | null>(null);
+  const [earnedAchievement, setEarnedAchievement] =
+    useState<EarnedAchievement | null>(null);
 
-  const generateRandomColors = useCallback(() => {
+  const level = getLevel(xp);
+  const comboMultiplier = getComboMultiplier(streak);
+  const levelProgress = getLevelProgress(xp);
+
+  // Monotonic id so effect-driven UI (floating score, button flash, toast) can
+  // key off a distinct value even when the underlying content repeats.
+  const eventIdRef = useRef(0);
+
+  const generateRound = useCallback((difficulty: number) => {
     const actualColor = generateRandomColor();
     const distractorColors = new Set<string>();
 
     while (distractorColors.size < 2) {
-      const candidate = generateRandomColor();
+      const candidate = generateDistractor(actualColor, difficulty);
       if (candidate !== actualColor && !distractorColors.has(candidate)) {
         distractorColors.add(candidate);
       }
@@ -30,40 +59,79 @@ export function useGuessColorsGame() {
     setAnswers(shuffleArray([actualColor, ...distractorColors]));
   }, []);
 
+  // Level 1 (difficulty 0) leaves the base color generation untouched.
   useEffect(() => {
-    generateRandomColors();
-  }, [generateRandomColors]);
-
-  useEffect(() => {
-    setStats((prev) => {
-      const nextHighScore = Math.max(prev.highScore, score);
-      const nextBestStreak = Math.max(prev.bestStreak, streak);
-      if (
-        nextHighScore === prev.highScore &&
-        nextBestStreak === prev.bestStreak
-      ) {
-        return prev;
-      }
-      const next = { highScore: nextHighScore, bestStreak: nextBestStreak };
-      saveStats(next);
-      return next;
-    });
-  }, [score, streak]);
+    generateRound(0);
+  }, [generateRound]);
 
   const handleAnswerClicked = useCallback(
     (answer: string): void => {
-      if (answer === color) {
-        setResult(Result.Correct);
-        setScore((s) => s + 1);
-        setStreak((s) => s + 1);
-        generateRandomColors();
-      } else {
+      eventIdRef.current += 1;
+      const eventId = eventIdRef.current;
+
+      if (answer !== color) {
         setResult(Result.Wrong);
         setStreak(0);
         setShakeTrigger((t) => t + 1);
+        setLastAnswer({ answer, correct: false, id: eventId });
+        playSound("wrong");
+        return;
       }
+
+      const nextScore = score + 1;
+      const nextStreak = streak + 1;
+      const multiplier = getComboMultiplier(nextStreak);
+      const gained = BASE_POINTS * multiplier;
+      const nextXp = xp + gained;
+      const nextLevel = getLevel(nextXp);
+      const leveledUp = nextLevel > level;
+
+      setResult(Result.Correct);
+      setScore(nextScore);
+      setStreak(nextStreak);
+      setXp(nextXp);
+      setPointsAwarded({ value: gained, multiplier, id: eventId });
+      setLastAnswer({ answer, correct: true, id: eventId });
+      setConfettiTrigger((t) => t + 1);
+      if (leveledUp) setLevelUpTrigger((t) => t + 1);
+
+      // Persist records and evaluate achievements against the new game state.
+      // Records only ever grow on a correct answer, so this is the single place
+      // stats need saving.
+      const bestStreak = Math.max(stats.bestStreak, nextStreak);
+      const newUnlocks = evaluateNewUnlocks(
+        {
+          score: nextScore,
+          streak: nextStreak,
+          bestStreak,
+          level: nextLevel,
+        },
+        stats.unlockedAchievements,
+      );
+      const nextStats = {
+        highScore: Math.max(stats.highScore, nextScore),
+        bestStreak,
+        bestLevel: Math.max(stats.bestLevel, nextLevel),
+        unlockedAchievements: newUnlocks.length
+          ? [...stats.unlockedAchievements, ...newUnlocks]
+          : stats.unlockedAchievements,
+      };
+      setStats(nextStats);
+      saveStats(nextStats);
+
+      if (newUnlocks.length) {
+        const unlocked = getAchievement(newUnlocks[0]);
+        if (unlocked) {
+          setEarnedAchievement({ ...unlocked, nonce: eventId });
+        }
+        playSound("achievement");
+      } else {
+        playSound(leveledUp ? "levelUp" : "correct");
+      }
+
+      generateRound(Math.max(0, nextLevel - 1));
     },
-    [color, generateRandomColors],
+    [color, score, streak, xp, level, stats, generateRound],
   );
 
   useEffect(() => {
@@ -89,9 +157,20 @@ export function useGuessColorsGame() {
     result,
     score,
     streak,
+    xp,
+    level,
+    comboMultiplier,
+    levelProgress,
     highScore: stats.highScore,
     bestStreak: stats.bestStreak,
+    bestLevel: stats.bestLevel,
+    unlockedAchievements: stats.unlockedAchievements,
     shakeTrigger,
+    confettiTrigger,
+    levelUpTrigger,
+    pointsAwarded,
+    lastAnswer,
+    earnedAchievement,
     handleAnswerClicked,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,3 +2,19 @@ export enum Result {
   Correct,
   Wrong,
 }
+
+// A snapshot of the game used to decide which achievements are unlocked.
+export type AchievementContext = {
+  score: number;
+  streak: number;
+  bestStreak: number;
+  level: number;
+};
+
+export type Achievement = {
+  id: string;
+  label: string;
+  emoji: string;
+  description: string;
+  isUnlocked: (ctx: AchievementContext) => boolean;
+};

--- a/src/utils/achievements.ts
+++ b/src/utils/achievements.ts
@@ -1,0 +1,74 @@
+import type { Achievement, AchievementContext } from "../types";
+
+// Badges the player can earn. Each is a pure predicate over the current game
+// snapshot, so unlocks are trivial to evaluate and test. Order here is the
+// display order.
+export const ACHIEVEMENTS: Achievement[] = [
+  {
+    id: "first-win",
+    label: "First Win",
+    emoji: "🎯",
+    description: "Guess your first color.",
+    isUnlocked: (ctx) => ctx.score >= 1,
+  },
+  {
+    id: "score-10",
+    label: "Getting Good",
+    emoji: "⭐",
+    description: "Reach a score of 10.",
+    isUnlocked: (ctx) => ctx.score >= 10,
+  },
+  {
+    id: "score-25",
+    label: "Color Master",
+    emoji: "🏆",
+    description: "Reach a score of 25.",
+    isUnlocked: (ctx) => ctx.score >= 25,
+  },
+  {
+    id: "streak-5",
+    label: "On Fire",
+    emoji: "🔥",
+    description: "Hit a 5-answer streak.",
+    isUnlocked: (ctx) => ctx.bestStreak >= 5,
+  },
+  {
+    id: "streak-10",
+    label: "Unstoppable",
+    emoji: "⚡",
+    description: "Hit a 10-answer streak.",
+    isUnlocked: (ctx) => ctx.bestStreak >= 10,
+  },
+  {
+    id: "level-3",
+    label: "Rising Star",
+    emoji: "🚀",
+    description: "Reach level 3.",
+    isUnlocked: (ctx) => ctx.level >= 3,
+  },
+  {
+    id: "level-5",
+    label: "Chromatic Royalty",
+    emoji: "👑",
+    description: "Reach level 5.",
+    isUnlocked: (ctx) => ctx.level >= 5,
+  },
+];
+
+const BY_ID = new Map(ACHIEVEMENTS.map((a) => [a.id, a]));
+
+export function getAchievement(id: string): Achievement | undefined {
+  return BY_ID.get(id);
+}
+
+// Returns the ids of achievements that are unlocked by `ctx` but were not
+// already in `alreadyUnlocked` — i.e. the ones earned right now.
+export function evaluateNewUnlocks(
+  ctx: AchievementContext,
+  alreadyUnlocked: readonly string[],
+): string[] {
+  const owned = new Set(alreadyUnlocked);
+  return ACHIEVEMENTS.filter((a) => !owned.has(a.id) && a.isUnlocked(ctx)).map(
+    (a) => a.id,
+  );
+}

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -26,6 +26,18 @@ function hslToHex(hue: number, saturation: number, lightness: number): string {
   );
 }
 
+// The HSL ranges vivid mid-tone colors are drawn from. Kept as named constants
+// so `generateDistractor` can nudge a target *within* the same gamut instead of
+// wandering off into near-white/near-black/gray.
+const SATURATION_MIN = 65;
+const SATURATION_MAX = 90;
+const LIGHTNESS_MIN = 45;
+const LIGHTNESS_MAX = 60;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
 // A single Math.random() draw per color: hue is uniform, while saturation and
 // lightness are derived from the same draw but clamped to vivid mid-tones so
 // a swatch can never be near-white, near-black, or gray — it must stay
@@ -33,7 +45,71 @@ function hslToHex(hue: number, saturation: number, lightness: number): string {
 export const generateRandomColor = () => {
   const r = Math.random();
   const hue = (r * 360) % 360;
-  const saturation = 65 + ((r * 9973) % 1) * 25;
-  const lightness = 45 + ((r * 5417) % 1) * 15;
+  const saturation =
+    SATURATION_MIN + ((r * 9973) % 1) * (SATURATION_MAX - SATURATION_MIN);
+  const lightness =
+    LIGHTNESS_MIN + ((r * 5417) % 1) * (LIGHTNESS_MAX - LIGHTNESS_MIN);
   return hslToHex(hue, saturation, lightness);
 };
+
+// Generates a distractor color for a given difficulty.
+//
+// At difficulty 0 (level 1) this is *exactly* `generateRandomColor()` — the
+// target is ignored and a fresh vivid color is drawn — so the base game and its
+// seeded tests are unaffected. At higher difficulty the distractor is nudged
+// from the target's own hue/saturation/lightness by a delta that shrinks as
+// difficulty rises, making the wrong options progressively closer (harder) to
+// the correct swatch. The caller is still responsible for rejecting exact
+// duplicates.
+export const generateDistractor = (
+  targetColor: string,
+  difficulty: number,
+): string => {
+  if (difficulty <= 0) return generateRandomColor();
+
+  const { h, s, l } = hexToHsl(targetColor);
+  // Hue window narrows from ~90deg down toward ~18deg as difficulty climbs.
+  const hueSpread = Math.max(18, 90 - (difficulty - 1) * 14);
+  const satSpread = Math.max(6, 20 - (difficulty - 1) * 3);
+  const lightSpread = Math.max(4, 14 - (difficulty - 1) * 2);
+
+  const hue = (h + (Math.random() * 2 - 1) * hueSpread + 360) % 360;
+  const saturation = clamp(
+    s + (Math.random() * 2 - 1) * satSpread,
+    SATURATION_MIN,
+    SATURATION_MAX,
+  );
+  const lightness = clamp(
+    l + (Math.random() * 2 - 1) * lightSpread,
+    LIGHTNESS_MIN,
+    LIGHTNESS_MAX,
+  );
+  return hslToHex(hue, saturation, lightness);
+};
+
+// Parses a #rrggbb string back into HSL degrees/percentages. Used by
+// `generateDistractor` to perturb a color relative to the target.
+function hexToHsl(hex: string): { h: number; s: number; l: number } {
+  const value = hex.replace("#", "");
+  const r = parseInt(value.slice(0, 2), 16) / 255;
+  const g = parseInt(value.slice(2, 4), 16) / 255;
+  const b = parseInt(value.slice(4, 6), 16) / 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const delta = max - min;
+  const l = (max + min) / 2;
+
+  let h = 0;
+  let s = 0;
+  if (delta !== 0) {
+    s = delta / (1 - Math.abs(2 * l - 1));
+    if (max === r) h = ((g - b) / delta) % 6;
+    else if (max === g) h = (b - r) / delta + 2;
+    else h = (r - g) / delta + 4;
+    h *= 60;
+    if (h < 0) h += 360;
+  }
+
+  return { h, s: s * 100, l: l * 100 };
+}

--- a/src/utils/levels.ts
+++ b/src/utils/levels.ts
@@ -1,0 +1,58 @@
+// Points and progression math for the game.
+//
+// A correct answer awards BASE_POINTS multiplied by the current combo
+// multiplier (a function of the running streak). Those points accumulate as XP,
+// which drives the player's level. Difficulty is derived from the level
+// (level - 1), so the very first level leaves the base round generation
+// untouched — see `generateDistractor` in `color.ts`.
+
+export const BASE_POINTS = 10;
+
+// The combo multiplier climbs one step for every third consecutive correct
+// answer, capped at 5x, so a long streak is worth noticeably more per answer.
+//   streak 1-2 -> 1x, 3-5 -> 2x, 6-8 -> 3x, 9-11 -> 4x, 12+ -> 5x
+export function getComboMultiplier(streak: number): number {
+  if (streak <= 0) return 1;
+  return Math.min(1 + Math.floor(streak / 3), 5);
+}
+
+// Cumulative XP required to *reach* a given level (level 1 starts at 0). Each
+// level costs a little more than the last: advancing from level L costs
+// (20 + 10 * L) XP. Level 2 therefore needs 30 XP — more than the 20 XP two
+// correct answers can produce — which keeps the early game (and the seeded unit
+// tests) at level 1, difficulty 0.
+export function xpForLevel(level: number): number {
+  const l = Math.max(1, Math.floor(level));
+  if (l <= 1) return 0;
+  const steps = l - 1;
+  return 20 * steps + 5 * l * steps;
+}
+
+export function getLevel(xp: number): number {
+  let level = 1;
+  while (xp >= xpForLevel(level + 1)) {
+    level += 1;
+  }
+  return level;
+}
+
+export type LevelProgress = {
+  level: number;
+  into: number;
+  needed: number;
+  ratio: number;
+};
+
+export function getLevelProgress(xp: number): LevelProgress {
+  const level = getLevel(xp);
+  const floor = xpForLevel(level);
+  const ceil = xpForLevel(level + 1);
+  const needed = ceil - floor;
+  const into = xp - floor;
+  return {
+    level,
+    into,
+    needed,
+    ratio: needed > 0 ? into / needed : 0,
+  };
+}

--- a/src/utils/sound.ts
+++ b/src/utils/sound.ts
@@ -1,0 +1,102 @@
+// A tiny WebAudio blip generator. No assets — each sound is one or more short
+// oscillator tones. Everything is guarded so it safely no-ops where WebAudio is
+// unavailable (jsdom under test, private browsing, older browsers).
+
+export type SoundKind = "correct" | "wrong" | "levelUp" | "achievement";
+
+const MUTE_STORAGE_KEY = "guessColors.muted";
+
+type Tone = {
+  freq: number;
+  start: number;
+  duration: number;
+  type?: OscillatorType;
+};
+
+// Each sound is a small score of tones (seconds are relative to play time).
+const SCORES: Record<SoundKind, Tone[]> = {
+  correct: [
+    { freq: 587.33, start: 0, duration: 0.12 }, // D5
+    { freq: 880.0, start: 0.09, duration: 0.16 }, // A5
+  ],
+  wrong: [{ freq: 155.56, start: 0, duration: 0.22, type: "sawtooth" }], // low Eb3
+  levelUp: [
+    { freq: 523.25, start: 0, duration: 0.12 }, // C5
+    { freq: 659.25, start: 0.1, duration: 0.12 }, // E5
+    { freq: 783.99, start: 0.2, duration: 0.18 }, // G5
+  ],
+  achievement: [
+    { freq: 659.25, start: 0, duration: 0.1 }, // E5
+    { freq: 987.77, start: 0.09, duration: 0.22 }, // B5
+  ],
+};
+
+function readInitialMuted(): boolean {
+  try {
+    return localStorage.getItem(MUTE_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+let muted = readInitialMuted();
+let context: AudioContext | null = null;
+
+function getContext(): AudioContext | null {
+  if (typeof window === "undefined") return null;
+  const Ctor =
+    window.AudioContext ??
+    (window as unknown as { webkitAudioContext?: typeof AudioContext })
+      .webkitAudioContext;
+  if (!Ctor) return null;
+  try {
+    if (!context) context = new Ctor();
+    if (context.state === "suspended") void context.resume();
+    return context;
+  } catch {
+    return null;
+  }
+}
+
+export function isMuted(): boolean {
+  return muted;
+}
+
+export function setMuted(next: boolean): void {
+  muted = next;
+  try {
+    localStorage.setItem(MUTE_STORAGE_KEY, String(next));
+  } catch {
+    // Storage may be unavailable; the in-memory flag still applies this session.
+  }
+}
+
+export function playSound(kind: SoundKind): void {
+  if (muted) return;
+  const ctx = getContext();
+  if (!ctx) return;
+
+  try {
+    const now = ctx.currentTime;
+    for (const tone of SCORES[kind]) {
+      const oscillator = ctx.createOscillator();
+      const gain = ctx.createGain();
+      oscillator.type = tone.type ?? "sine";
+      oscillator.frequency.value = tone.freq;
+
+      const startAt = now + tone.start;
+      const endAt = startAt + tone.duration;
+      // Quick attack, exponential release so blips don't click.
+      gain.gain.setValueAtTime(0.0001, startAt);
+      gain.gain.exponentialRampToValueAtTime(0.15, startAt + 0.01);
+      gain.gain.exponentialRampToValueAtTime(0.0001, endAt);
+
+      oscillator.connect(gain);
+      gain.connect(ctx.destination);
+      oscillator.start(startAt);
+      oscillator.stop(endAt + 0.02);
+    }
+  } catch {
+    // Ignore any audio failure — sound is a non-essential enhancement.
+  }
+}

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -1,27 +1,55 @@
 export type Stats = {
   highScore: number;
   bestStreak: number;
+  bestLevel: number;
+  unlockedAchievements: string[];
 };
 
 const STORAGE_KEY = "guessColors.stats";
-const DEFAULT_STATS: Stats = { highScore: 0, bestStreak: 0 };
+const DEFAULT_STATS: Stats = {
+  highScore: 0,
+  bestStreak: 0,
+  bestLevel: 1,
+  unlockedAchievements: [],
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
 
 export function loadStats(): Stats {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return DEFAULT_STATS;
 
-    const parsed = JSON.parse(raw);
+    const parsed: unknown = JSON.parse(raw);
     if (
-      typeof parsed !== "object" ||
-      parsed === null ||
+      !isRecord(parsed) ||
       typeof parsed.highScore !== "number" ||
       typeof parsed.bestStreak !== "number"
     ) {
       return DEFAULT_STATS;
     }
 
-    return { highScore: parsed.highScore, bestStreak: parsed.bestStreak };
+    // `bestLevel` and `unlockedAchievements` were added later; tolerate saves
+    // that predate them by falling back to the defaults for missing/invalid
+    // fields instead of discarding the whole record.
+    const bestLevel =
+      typeof parsed.bestLevel === "number" && parsed.bestLevel >= 1
+        ? parsed.bestLevel
+        : DEFAULT_STATS.bestLevel;
+    const unlockedAchievements =
+      Array.isArray(parsed.unlockedAchievements) &&
+      parsed.unlockedAchievements.every((id) => typeof id === "string")
+        ? (parsed.unlockedAchievements as string[])
+        : DEFAULT_STATS.unlockedAchievements;
+
+    return {
+      highScore: parsed.highScore,
+      bestStreak: parsed.bestStreak,
+      bestLevel,
+      unlockedAchievements,
+    };
   } catch {
     return DEFAULT_STATS;
   }


### PR DESCRIPTION
Build a richer reward loop on top of the existing score/streak base.

Gamification:
- XP + animated level progress bar (XpBar, utils/levels.ts)
- Streak-based combo point multiplier (up to x5) feeding XP, shown as a badge
- Level-driven difficulty: distractors tighten toward the target as levels
  rise (generateDistractor in utils/color.ts); level 1 is unchanged so the
  base game and seeded tests are unaffected
- Achievements with a toast and localStorage persistence (utils/achievements.ts)

Micro-interactions (all reduced-motion aware):
- Confetti burst on correct answers
- Floating "+N xCombo" score popups from the swatch
- Correct/wrong button flashes
- WebAudio sound effects with a persisted mute toggle (utils/sound.ts,
  SoundToggle); safe no-op where WebAudio is unavailable

Persistence (utils/stats.ts) now also tracks best level and unlocked
achievements, loading older saves in a backward-compatible way.

Score remains a plain per-correct counter; combos feed the separate XP value.
Adds unit tests for the new utils/components and e2e coverage for XP, button
flash, confetti, and the mute toggle. Lint, typecheck, unit (90% coverage),
build, and e2e all pass.
