### PR TITLE
Refine gamification: persist XP, visible success cue, achievements gallery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,16 +20,27 @@ number, most recent first.
   - **Achievements** — unlockable badges (first win, score/streak/level
     milestones) defined in `src/utils/achievements.ts`, announced via a toast
     (`AchievementToast`) and persisted in `localStorage`.
+  - **Achievements gallery** — a persistent `AchievementsBar` shows every badge
+    (dimmed while locked, lit once earned) with an earned/total count, so the
+    collection is visible beyond the fleeting unlock toast. Unlocked state is
+    conveyed via `aria-label`, not color alone.
 - Micro-interactions, all respecting `prefers-reduced-motion`:
   - A **confetti burst** (`Confetti`) on correct answers.
+  - A **success pulse** (`SuccessPulse`) — a green ring flash over the swatch on
+    a correct answer. (The swatch stays mounted across rounds, so the "correct"
+    cue lives there; a correct guess regenerates the answer buttons immediately,
+    which is why the button flash is reserved for wrong answers.)
   - **Floating `+N ×combo` score popups** (`FloatingScore`) rising from the swatch.
-  - **Correct/wrong button flashes** on the answer options.
+  - A **wrong-answer button flash** on the option that was missed.
   - **Sound effects** (WebAudio blips for correct/wrong/level-up/achievement) via
     `src/utils/sound.ts`, with a persisted **mute toggle** (`SoundToggle`) beside
     the theme toggle. Audio degrades to a safe no-op where WebAudio is
     unavailable.
-- Persistence (`src/utils/stats.ts`) now also tracks the best level reached and
-  unlocked achievements, with backward-compatible loading of older saves.
+- Persistence (`src/utils/stats.ts`) now also tracks accumulated **XP** and
+  unlocked achievements, with backward-compatible loading of older saves. XP —
+  and therefore level and difficulty — is long-term progression that carries
+  across reloads, so a returning player resumes at their earned level and
+  difficulty (score and streak still reset each session).
 - A playful visual redesign built on Tailwind CSS v4: gradient page background,
   centered game card, pill-style score chips, chunky answer buttons with
   visible 1/2/3 key hints, a bundled Nunito font, and a glow on the swatch

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { MotionConfig } from "motion/react";
+import { AchievementsBar } from "./components/AchievementsBar";
 import { AchievementToast } from "./components/AchievementToast";
 import { AnswerOptions } from "./components/AnswerOptions";
 import { ColorSwatch } from "./components/ColorSwatch";
@@ -7,6 +8,7 @@ import { FloatingScore } from "./components/FloatingScore";
 import { ResultMessage } from "./components/ResultMessage";
 import { ScoreBoard } from "./components/ScoreBoard";
 import { SoundToggle } from "./components/SoundToggle";
+import { SuccessPulse } from "./components/SuccessPulse";
 import { ThemeToggle } from "./components/ThemeToggle";
 import { XpBar } from "./components/XpBar";
 import { useGuessColorsGame } from "./hooks/useGuessColorsGame";
@@ -28,6 +30,7 @@ function App() {
     pointsAwarded,
     lastAnswer,
     earnedAchievement,
+    unlockedAchievements,
     handleAnswerClicked,
   } = useGuessColorsGame();
 
@@ -51,6 +54,7 @@ function App() {
           />
           <div className="relative w-full">
             <ColorSwatch color={color} shakeTrigger={shakeTrigger} />
+            <SuccessPulse trigger={pointsAwarded?.id ?? 0} />
             <FloatingScore points={pointsAwarded} />
           </div>
           <AnswerOptions
@@ -59,6 +63,7 @@ function App() {
             onSelect={handleAnswerClicked}
           />
           <ResultMessage result={result} />
+          <AchievementsBar unlocked={unlockedAchievements} />
         </main>
         <AchievementToast achievement={earnedAchievement} />
       </div>

--- a/src/__tests__/AchievementsBar.test.jsx
+++ b/src/__tests__/AchievementsBar.test.jsx
@@ -1,0 +1,27 @@
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { AchievementsBar } from "../components/AchievementsBar";
+import { ACHIEVEMENTS } from "../utils/achievements";
+
+test("renders every achievement with its locked/unlocked count", () => {
+  const { getByText, getAllByRole } = render(
+    <AchievementsBar unlocked={["first-win"]} />,
+  );
+
+  expect(getAllByRole("listitem")).toHaveLength(ACHIEVEMENTS.length);
+  expect(getByText(`1 / ${ACHIEVEMENTS.length}`)).toBeInTheDocument();
+});
+
+test("conveys unlocked state through accessible labels, not color alone", () => {
+  const { getByLabelText } = render(
+    <AchievementsBar unlocked={["first-win"]} />,
+  );
+
+  expect(getByLabelText("First Win, unlocked")).toBeInTheDocument();
+  expect(getByLabelText("On Fire, locked")).toBeInTheDocument();
+});
+
+test("shows nothing unlocked when the list is empty", () => {
+  const { getByText } = render(<AchievementsBar unlocked={[]} />);
+  expect(getByText(`0 / ${ACHIEVEMENTS.length}`)).toBeInTheDocument();
+});

--- a/src/__tests__/SuccessPulse.test.jsx
+++ b/src/__tests__/SuccessPulse.test.jsx
@@ -1,0 +1,28 @@
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { SuccessPulse } from "../components/SuccessPulse";
+import { setPrefersReducedMotion } from "../test/setup";
+
+test("stays idle before any trigger", () => {
+  const { container } = render(<SuccessPulse trigger={0} />);
+  const root = container.querySelector("[data-success-pulse]");
+  expect(root).toHaveAttribute("data-success-pulse", "idle");
+});
+
+test("flashes when the trigger increments", () => {
+  const { container, rerender } = render(<SuccessPulse trigger={0} />);
+
+  rerender(<SuccessPulse trigger={1} />);
+
+  const root = container.querySelector("[data-success-pulse]");
+  expect(root).toHaveAttribute("data-success-pulse", "active");
+});
+
+test("renders nothing under reduced motion", () => {
+  setPrefersReducedMotion(true);
+  const { container, rerender } = render(<SuccessPulse trigger={0} />);
+
+  rerender(<SuccessPulse trigger={1} />);
+
+  expect(container.querySelector("[data-success-pulse]")).toBeNull();
+});

--- a/src/__tests__/stats.test.js
+++ b/src/__tests__/stats.test.js
@@ -3,7 +3,7 @@ import { loadStats, saveStats } from "../utils/stats";
 const DEFAULTS = {
   highScore: 0,
   bestStreak: 0,
-  bestLevel: 1,
+  xp: 0,
   unlockedAchievements: [],
 };
 
@@ -19,7 +19,7 @@ test("returns the persisted values when present", () => {
   const stats = {
     highScore: 5,
     bestStreak: 3,
-    bestLevel: 4,
+    xp: 120,
     unlockedAchievements: ["first-win", "streak-5"],
   };
   saveStats(stats);
@@ -39,16 +39,16 @@ test("falls back to defaults when the stored value is the wrong shape", () => {
   expect(loadStats()).toEqual(DEFAULTS);
 });
 
-test("migrates an older save that predates bestLevel/achievements", () => {
+test("migrates an older save that predates xp/achievements (and drops bestLevel)", () => {
   localStorage.setItem(
     "guessColors.stats",
-    JSON.stringify({ highScore: 7, bestStreak: 4 }),
+    JSON.stringify({ highScore: 7, bestStreak: 4, bestLevel: 3 }),
   );
 
   expect(loadStats()).toEqual({
     highScore: 7,
     bestStreak: 4,
-    bestLevel: 1,
+    xp: 0,
     unlockedAchievements: [],
   });
 });
@@ -59,7 +59,7 @@ test("ignores an invalid unlockedAchievements array", () => {
     JSON.stringify({
       highScore: 2,
       bestStreak: 1,
-      bestLevel: 2,
+      xp: 40,
       unlockedAchievements: [1, "first-win"],
     }),
   );
@@ -67,7 +67,7 @@ test("ignores an invalid unlockedAchievements array", () => {
   expect(loadStats()).toEqual({
     highScore: 2,
     bestStreak: 1,
-    bestLevel: 2,
+    xp: 40,
     unlockedAchievements: [],
   });
 });

--- a/src/components/AchievementsBar.tsx
+++ b/src/components/AchievementsBar.tsx
@@ -1,0 +1,53 @@
+import { motion } from "motion/react";
+import { ACHIEVEMENTS } from "../utils/achievements";
+
+type AchievementsBarProps = {
+  unlocked: string[];
+};
+
+// A persistent row of every badge, dimmed while locked and lit once earned, so
+// players can see their collection and what's left — not just the fleeting
+// unlock toast. State is conveyed via aria-label, not color alone.
+export function AchievementsBar({ unlocked }: AchievementsBarProps) {
+  const owned = new Set(unlocked);
+
+  return (
+    <section aria-label="Achievements" className="w-full">
+      <div className="mb-1 flex items-center justify-between text-xs font-bold text-slate-600 dark:text-slate-300">
+        <span>Achievements</span>
+        <span>
+          {owned.size} / {ACHIEVEMENTS.length}
+        </span>
+      </div>
+      <ul className="flex flex-wrap justify-center gap-2">
+        {ACHIEVEMENTS.map((achievement) => {
+          const isUnlocked = owned.has(achievement.id);
+          return (
+            <li key={achievement.id}>
+              <motion.span
+                role="img"
+                data-unlocked={isUnlocked}
+                title={`${achievement.label} — ${achievement.description}${
+                  isUnlocked ? "" : " (locked)"
+                }`}
+                aria-label={`${achievement.label}, ${
+                  isUnlocked ? "unlocked" : "locked"
+                }`}
+                initial={false}
+                animate={{ scale: isUnlocked ? 1 : 0.92 }}
+                transition={{ type: "spring", stiffness: 500, damping: 20 }}
+                className={`grid size-9 place-items-center rounded-full text-lg ring-1 ${
+                  isUnlocked
+                    ? "bg-amber-100 ring-amber-400 dark:bg-amber-500/25 dark:ring-amber-400/70"
+                    : "bg-slate-100 opacity-40 ring-slate-300 grayscale dark:bg-slate-700 dark:ring-slate-600"
+                }`}
+              >
+                <span aria-hidden="true">{achievement.emoji}</span>
+              </motion.span>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/AnswerOptions.tsx
+++ b/src/components/AnswerOptions.tsx
@@ -15,9 +15,6 @@ const baseButton =
 const idleButton =
   "border-violet-300 bg-violet-100 text-slate-900 focus-visible:ring-violet-500 dark:border-violet-950 dark:bg-slate-700 dark:text-slate-100 dark:focus-visible:ring-violet-400";
 
-const correctButton =
-  "border-green-500 bg-green-200 text-green-950 focus-visible:ring-green-500 dark:border-green-400 dark:bg-green-500 dark:text-green-950";
-
 const wrongButton =
   "border-rose-500 bg-rose-200 text-rose-950 focus-visible:ring-rose-500 dark:border-rose-400 dark:bg-rose-500 dark:text-rose-950";
 
@@ -29,14 +26,10 @@ export function AnswerOptions({
   return (
     <div className="flex w-full flex-col gap-3 sm:flex-row">
       {answers.map((answer, index) => {
-        const flashed = lastAnswer?.answer === answer;
-        const flashCorrect = flashed && lastAnswer?.correct;
-        const flashWrong = flashed && lastAnswer && !lastAnswer.correct;
-        const stateClass = flashCorrect
-          ? correctButton
-          : flashWrong
-            ? wrongButton
-            : idleButton;
+        // A correct answer immediately regenerates the round (new buttons), so
+        // only a wrong answer's button lingers to be flashed — the correct cue
+        // lives on the persistent swatch (see SuccessPulse) instead.
+        const flashWrong = lastAnswer?.answer === answer && !lastAnswer.correct;
 
         return (
           <motion.button
@@ -44,18 +37,12 @@ export function AnswerOptions({
             onClick={() => onSelect(answer)}
             key={answer}
             aria-keyshortcuts={String(index + 1)}
-            data-flash={
-              flashCorrect ? "correct" : flashWrong ? "wrong" : "none"
-            }
+            data-flash={flashWrong ? "wrong" : "none"}
             whileHover={{ y: -3 }}
             whileTap={{ scale: 0.92 }}
-            animate={
-              flashed
-                ? { scale: [1, flashCorrect ? 1.06 : 0.97, 1] }
-                : { scale: 1 }
-            }
+            animate={flashWrong ? { scale: [1, 0.97, 1] } : { scale: 1 }}
             transition={buttonSpring}
-            className={`${baseButton} ${stateClass}`}
+            className={`${baseButton} ${flashWrong ? wrongButton : idleButton}`}
           >
             {/* biome-ignore lint/a11y/noAriaHiddenOnFocusable: the <kbd> hint is decorative and not focusable; hiding it keeps the button's accessible name exactly the hex label */}
             <kbd

--- a/src/components/SuccessPulse.tsx
+++ b/src/components/SuccessPulse.tsx
@@ -1,0 +1,43 @@
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { useEffect, useState } from "react";
+
+type SuccessPulseProps = {
+  trigger: number;
+};
+
+// A green ring that flashes over the swatch on a correct answer. Because a
+// correct guess regenerates the answer buttons immediately, the buttons can't
+// linger to flash — so the "correct" cue lives here, on the swatch, which stays
+// mounted. Renders nothing under prefers-reduced-motion.
+export function SuccessPulse({ trigger }: SuccessPulseProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const [active, setActive] = useState(0);
+
+  useEffect(() => {
+    if (trigger === 0 || prefersReducedMotion) return;
+    setActive(trigger);
+  }, [trigger, prefersReducedMotion]);
+
+  if (prefersReducedMotion) return null;
+
+  return (
+    <div
+      aria-hidden="true"
+      data-success-pulse={active > 0 ? "active" : "idle"}
+      className="pointer-events-none absolute inset-0 z-10 overflow-hidden rounded-2xl"
+    >
+      <AnimatePresence>
+        {active > 0 && (
+          <motion.span
+            key={active}
+            className="absolute inset-0 rounded-2xl ring-4 ring-green-400"
+            initial={{ opacity: 0.9, scale: 1 }}
+            animate={{ opacity: 0, scale: 1.06 }}
+            transition={{ duration: 0.5, ease: "easeOut" }}
+            onAnimationComplete={() => setActive(0)}
+          />
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/hooks/useGuessColorsGame.ts
+++ b/src/hooks/useGuessColorsGame.ts
@@ -24,8 +24,10 @@ export function useGuessColorsGame() {
   const [result, setResult] = useState<Result | undefined>(undefined);
   const [score, setScore] = useState(0);
   const [streak, setStreak] = useState(0);
-  const [xp, setXp] = useState(0);
   const [stats, setStats] = useState(() => loadStats());
+  // XP (and therefore level and difficulty) is long-term progression that
+  // persists across sessions, unlike the per-session score and streak.
+  const [xp, setXp] = useState(() => stats.xp);
   const [shakeTrigger, setShakeTrigger] = useState(0);
   const [confettiTrigger, setConfettiTrigger] = useState(0);
   const [levelUpTrigger, setLevelUpTrigger] = useState(0);
@@ -44,6 +46,10 @@ export function useGuessColorsGame() {
   // key off a distinct value even when the underlying content repeats.
   const eventIdRef = useRef(0);
 
+  // Difficulty for the very first round, derived once from the persisted level
+  // so returning players resume at their level instead of restarting easy.
+  const startDifficultyRef = useRef(Math.max(0, level - 1));
+
   const generateRound = useCallback((difficulty: number) => {
     const actualColor = generateRandomColor();
     const distractorColors = new Set<string>();
@@ -59,9 +65,10 @@ export function useGuessColorsGame() {
     setAnswers(shuffleArray([actualColor, ...distractorColors]));
   }, []);
 
-  // Level 1 (difficulty 0) leaves the base color generation untouched.
+  // Level 1 (difficulty 0) leaves the base color generation untouched; a
+  // returning player at a higher level starts at their earned difficulty.
   useEffect(() => {
-    generateRound(0);
+    generateRound(startDifficultyRef.current);
   }, [generateRound]);
 
   const handleAnswerClicked = useCallback(
@@ -111,7 +118,7 @@ export function useGuessColorsGame() {
       const nextStats = {
         highScore: Math.max(stats.highScore, nextScore),
         bestStreak,
-        bestLevel: Math.max(stats.bestLevel, nextLevel),
+        xp: nextXp,
         unlockedAchievements: newUnlocks.length
           ? [...stats.unlockedAchievements, ...newUnlocks]
           : stats.unlockedAchievements,
@@ -163,7 +170,6 @@ export function useGuessColorsGame() {
     levelProgress,
     highScore: stats.highScore,
     bestStreak: stats.bestStreak,
-    bestLevel: stats.bestLevel,
     unlockedAchievements: stats.unlockedAchievements,
     shakeTrigger,
     confettiTrigger,

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -1,7 +1,7 @@
 export type Stats = {
   highScore: number;
   bestStreak: number;
-  bestLevel: number;
+  xp: number;
   unlockedAchievements: string[];
 };
 
@@ -9,7 +9,7 @@ const STORAGE_KEY = "guessColors.stats";
 const DEFAULT_STATS: Stats = {
   highScore: 0,
   bestStreak: 0,
-  bestLevel: 1,
+  xp: 0,
   unlockedAchievements: [],
 };
 
@@ -31,13 +31,15 @@ export function loadStats(): Stats {
       return DEFAULT_STATS;
     }
 
-    // `bestLevel` and `unlockedAchievements` were added later; tolerate saves
-    // that predate them by falling back to the defaults for missing/invalid
-    // fields instead of discarding the whole record.
-    const bestLevel =
-      typeof parsed.bestLevel === "number" && parsed.bestLevel >= 1
-        ? parsed.bestLevel
-        : DEFAULT_STATS.bestLevel;
+    // `xp` and `unlockedAchievements` were added later; tolerate saves that
+    // predate them by falling back to the defaults for missing/invalid fields
+    // instead of discarding the whole record. (An earlier build stored
+    // `bestLevel` instead of `xp`; it is simply ignored — level is now derived
+    // from the persisted xp.)
+    const xp =
+      typeof parsed.xp === "number" && parsed.xp >= 0
+        ? parsed.xp
+        : DEFAULT_STATS.xp;
     const unlockedAchievements =
       Array.isArray(parsed.unlockedAchievements) &&
       parsed.unlockedAchievements.every((id) => typeof id === "string")
@@ -47,7 +49,7 @@ export function loadStats(): Stats {
     return {
       highScore: parsed.highScore,
       bestStreak: parsed.bestStreak,
-      bestLevel,
+      xp,
       unlockedAchievements,
     };
   } catch {


### PR DESCRIPTION
Follow-up refinements to the gamification work merged in #32, addressing three improvement items.

## #2 + #3 — Persist XP so level and difficulty carry across reloads
XP is now long-term progression stored in `localStorage`, so a returning player resumes at their earned level **and** difficulty instead of restarting at level 1 with easy distractors. Score and streak still reset each session (unchanged). The redundant `bestLevel` field is replaced by `xp`; older saves load compatibly, and the first round's difficulty is seeded from the loaded level.

## #1 — Replace the never-visible correct button-flash with a swatch success pulse
A correct answer regenerates the answer buttons immediately, so the green button flash never actually rendered. The "correct" cue now lives on the persistent swatch as a green ring pulse (`SuccessPulse`), reduced-motion aware. The button flash is kept for **wrong** answers, where the button lingers.

## #6 — Add a persistent achievements gallery
`AchievementsBar` shows every badge (dimmed when locked, lit when earned) with an earned/total count, so unlocks are visible beyond the fleeting toast. State is conveyed via `aria-label` + `role="img"`, not color alone, and it passes the axe scans.

## Verification
- `pnpm lint` — clean
- `pnpm test:coverage` — 76 tests, 96.4% stmts / 92.1% branch / 94.2% funcs / 98.4% lines (≥90% threshold)
- `pnpm build` — clean
- `pnpm e2e` — 19 Playwright tests incl. axe accessibility scans
